### PR TITLE
Remove/rename args of kube-rbac-proxy to avoid unknown flag error on arm64

### DIFF
--- a/k8s-mediaserver-operator-arm64.yml
+++ b/k8s-mediaserver-operator-arm64.yml
@@ -282,8 +282,7 @@ spec:
           name: https
       - args:
         - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
-        - --leader-elect
+        - --metrics-addr=127.0.0.1:8080
         - --leader-election-id=k8s-mediaserver-operator
         image: quay.io/kubealex/k8s-mediaserver-operator:v0.3-arm64
         imagePullPolicy: Always


### PR DESCRIPTION
I was getting the following error and constant reboot of container "manager", because of "unknown flag" for "--metrics-bind-address" and "--leader-elect".

![Screenshot from 2021-07-11 17-51-42](https://user-images.githubusercontent.com/2628976/125207711-69077400-e296-11eb-901b-e5dbaa215257.png)