### PR TITLE
Added volumeMounts and resource values

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ The CR is quite simple to configure, and I tried to keep the number of parameter
 | general.storage.pvcName  | Name of the persistenVolumeClaim configured in deployments | mediaserver-pvc |
 | general.storage.pvcStorageClass  | Specifies a storageClass for the PVC | {} |
 | general.storage.size | Size of the persistenVolume | 50Gi |
+| general.storage.subPaths.tv | Default subpath for tv series folder on used storage | media/tv |
+| general.storage.subPaths.movies | Default subpath for movies folder on used storage | media/movies |
+| general.storage.subPaths.transmission | Default subpath for transmission downloads on used storage | downloads/transmission |
+| general.storage.subPaths.sabnzbd | Default subpath for sabnzbd downloads on used storage | downloads/sabnzbd |
+| general.storage.subPaths.config | Default subpath for all config files on used storage | config |
+
 
 # Plex
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ The CR is quite simple to configure, and I tried to keep the number of parameter
 | general.storage.subPaths.sabnzbd | Default subpath for sabnzbd downloads on used storage | downloads/sabnzbd |
 | general.storage.subPaths.config | Default subpath for all config files on used storage | config |
 
-
 # Plex
 
 | Config path | Meaning | Default | 

--- a/helm-charts/k8s-mediaserver/templates/jackett-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/jackett-resources.yml
@@ -55,7 +55,7 @@ spec:
               name: init-files-jackett
             - mountPath: /jackett-config
               name: mediaserver-volume
-              subPath: "config/jackett/Jackett"
+              subPath: "{{ .Values.general.storage.media.config }}/jackett/Jackett"
           securityContext:
             runAsUser: {{ .Values.general.puid }}
             runAsGroup: {{ .Values.general.pgid }}
@@ -78,7 +78,11 @@ spec:
           volumeMounts:
             - name: mediaserver-volume
               mountPath: "/config"
-              subPath: "config/jackett"
+              subPath: "{{ .Values.general.storage.media.config }}/jackett"
+          {{- with .Values.jackett.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: mediaserver-volume
           persistentVolumeClaim:

--- a/helm-charts/k8s-mediaserver/templates/jackett-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/jackett-resources.yml
@@ -55,7 +55,7 @@ spec:
               name: init-files-jackett
             - mountPath: /jackett-config
               name: mediaserver-volume
-              subPath: "{{ .Values.general.storage.media.config }}/jackett/Jackett"
+              subPath: "{{ .Values.general.storage.subPaths.config }}/jackett/Jackett"
           securityContext:
             runAsUser: {{ .Values.general.puid }}
             runAsGroup: {{ .Values.general.pgid }}

--- a/helm-charts/k8s-mediaserver/templates/jackett-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/jackett-resources.yml
@@ -78,7 +78,7 @@ spec:
           volumeMounts:
             - name: mediaserver-volume
               mountPath: "/config"
-              subPath: "{{ .Values.general.storage.media.config }}/jackett"
+              subPath: "{{ .Values.general.storage.subPaths.config }}/jackett"
           {{- with .Values.jackett.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/helm-charts/k8s-mediaserver/templates/plex-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/plex-resources.yml
@@ -51,13 +51,13 @@ spec:
           volumeMounts:
             - name: mediaserver-volume
               mountPath: "/config"
-              subPath: "{{ .Values.general.storage.media.config }}/plex"
+              subPath: "{{ .Values.general.storage.subPaths.config }}/plex"
             - name: mediaserver-volume
               mountPath: "/movies"
-              subPath: "{{ .Values.general.storage.media.movies }}"
+              subPath: "{{ .Values.general.storage.subPaths.movies }}"
             - name: mediaserver-volume
               mountPath: "/tv"
-              subPath: "{{ .Values.general.storage.media.tv }}"
+              subPath: "{{ .Values.general.storage.subPaths.tv }}"
           {{- with .Values.plex.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/helm-charts/k8s-mediaserver/templates/plex-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/plex-resources.yml
@@ -51,13 +51,17 @@ spec:
           volumeMounts:
             - name: mediaserver-volume
               mountPath: "/config"
-              subPath: "config/plex"
+              subPath: "{{ .Values.general.storage.media.config }}/plex"
             - name: mediaserver-volume
               mountPath: "/movies"
-              subPath: "media/movies"
+              subPath: "{{ .Values.general.storage.media.movies }}"
             - name: mediaserver-volume
               mountPath: "/tv"
-              subPath: "media/tv"
+              subPath: "{{ .Values.general.storage.media.tv }}"
+          {{- with .Values.plex.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.general.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-charts/k8s-mediaserver/templates/radarr-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/radarr-resources.yml
@@ -56,7 +56,7 @@ spec:
               name: init-files-radarr 
             - mountPath: /radarr-config
               name: mediaserver-volume
-              subPath: "{{ .Values.general.storage.media.config }}/radarr"
+              subPath: "{{ .Values.general.storage.subPaths.config }}/radarr"
           securityContext:
             runAsUser: {{ .Values.general.puid }}
             runAsGroup: {{ .Values.general.pgid }}

--- a/helm-charts/k8s-mediaserver/templates/radarr-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/radarr-resources.yml
@@ -1,3 +1,8 @@
+{{- if .Values.sabnzbd.enabled }}
+{{- if .Values.transmission.enabled }}
+{{- fail "Transmission and Sabnzbd are mutually exclusive!" }}
+{{- end }}
+{{- end }}
 {{ if .Values.radarr.enabled }}
 ---
 ### CONFIGMAP

--- a/helm-charts/k8s-mediaserver/templates/radarr-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/radarr-resources.yml
@@ -79,13 +79,20 @@ spec:
           volumeMounts: 
             - name: mediaserver-volume
               mountPath: "/config"
-              subPath: "{{ .Values.general.storage.media.config }}/radarr"
+              subPath: "{{ .Values.general.storage.subPaths.config }}/radarr"
+{{ if .Values.transmission.enabled }}
             - name: mediaserver-volume
               mountPath: "/downloads"
-              subPath: "{{ .Values.general.storage.media.downloads }}"
+              subPath: "{{ .Values.general.storage.subPaths.transmission }}"
+{{ end }}
+{{ if .Values.sabnzbd.enabled }}
+            - name: mediaserver-volume
+              mountPath: "/downloads"
+              subPath: "{{ .Values.general.storage.subPaths.sabnzbd }}"
+{{ end }}
             - name: mediaserver-volume
               mountPath: "/movies"
-              subPath: "{{ .Values.general.storage.media.movies }}"
+              subPath: "{{ .Values.general.storage.subPaths.movies }}"
           {{- with .Values.radarr.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/helm-charts/k8s-mediaserver/templates/radarr-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/radarr-resources.yml
@@ -1,8 +1,3 @@
-{{- if .Values.sabnzbd.enabled }}
-{{- if .Values.transmission.enabled }}
-{{- fail "Transmission and Sabnzbd are mutually exclusive!" }}
-{{- end }}
-{{- end }}
 {{ if .Values.radarr.enabled }}
 ---
 ### CONFIGMAP

--- a/helm-charts/k8s-mediaserver/templates/radarr-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/radarr-resources.yml
@@ -53,10 +53,10 @@ spec:
           command: ["/init-radarr/init-radarr.sh"]
           volumeMounts:
             - mountPath: /init-radarr
-              name: init-files-radarr
+              name: init-files-radarr 
             - mountPath: /radarr-config
               name: mediaserver-volume
-              subPath: "config/radarr"
+              subPath: "{{ .Values.general.storage.media.config }}/radarr"
           securityContext:
             runAsUser: {{ .Values.general.puid }}
             runAsGroup: {{ .Values.general.pgid }}
@@ -76,16 +76,20 @@ spec:
             - name: radarr-port
               containerPort: {{ .Values.radarr.container.port }}
               protocol: TCP
-          volumeMounts:
+          volumeMounts: 
             - name: mediaserver-volume
               mountPath: "/config"
-              subPath: "config/radarr"
+              subPath: "{{ .Values.general.storage.media.config }}/radarr"
             - name: mediaserver-volume
               mountPath: "/downloads"
-              subPath: "downloads/transmission"
+              subPath: "{{ .Values.general.storage.media.downloads }}"
             - name: mediaserver-volume
               mountPath: "/movies"
-              subPath: "media/movies"
+              subPath: "{{ .Values.general.storage.media.movies }}"
+          {{- with .Values.radarr.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: mediaserver-volume
           persistentVolumeClaim:

--- a/helm-charts/k8s-mediaserver/templates/sabnzbd-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/sabnzbd-resources.yml
@@ -50,13 +50,13 @@ spec:
           volumeMounts:
             - name: mediaserver-volume
               mountPath: "/config"
-              subPath: "{{ .Values.general.storage.media.config }}/sabnzbd"
+              subPath: "{{ .Values.general.storage.subPaths.config }}/sabnzbd"
             - name: mediaserver-volume
               mountPath: "/downloads"
-              subPath: "{{ .Values.general.storage.media.sabnzbd }}/complete"
+              subPath: "{{ .Values.general.storage.subPaths.sabnzbd }}/complete"
             - name: mediaserver-volume
               mountPath: "/incomplete-downloads"
-              subPath: "{{ .Values.general.storage.media.sabnzbd }}/incomplete"
+              subPath: "{{ .Values.general.storage.subPaths.sabnzbd }}/incomplete"
           {{- with .Values.sabnzbd.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/helm-charts/k8s-mediaserver/templates/sabnzbd-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/sabnzbd-resources.yml
@@ -1,3 +1,9 @@
+{{- if .Values.sabnzbd.enabled }}
+{{- if .Values.transmission.enabled }}
+{{- fail "Transmission and Sabnzbd are mutually exclusive!" }}
+{{- end }}
+{{- end }}
+
 {{- if .Values.sabnzbd.enabled -}}
 ---
 ### CONFIGMAP

--- a/helm-charts/k8s-mediaserver/templates/sabnzbd-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/sabnzbd-resources.yml
@@ -50,13 +50,17 @@ spec:
           volumeMounts:
             - name: mediaserver-volume
               mountPath: "/config"
-              subPath: "config/sabnzbd"
+              subPath: "{{ .Values.general.storage.media.config }}/sabnzbd"
             - name: mediaserver-volume
               mountPath: "/downloads"
-              subPath: "downloads/sabnzbd/complete"
+              subPath: "{{ .Values.general.storage.media.sabnzbd }}/complete"
             - name: mediaserver-volume
               mountPath: "/incomplete-downloads"
-              subPath: "downloads/sabnzbd/incomplete"
+              subPath: "{{ .Values.general.storage.media.sabnzbd }}/incomplete"
+          {{- with .Values.sabnzbd.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: mediaserver-volume
           persistentVolumeClaim:

--- a/helm-charts/k8s-mediaserver/templates/sonarr-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/sonarr-resources.yml
@@ -55,7 +55,7 @@ spec:
               name: init-files-sonarr
             - mountPath: /sonarr-config
               name: mediaserver-volume
-              subPath: "{{ .Values.general.storage.media.config }}/sonarr"
+              subPath: "{{ .Values.general.storage.subPaths.config }}/sonarr"
           securityContext:
             runAsUser: {{ .Values.general.puid }}
             runAsGroup: {{ .Values.general.pgid }}

--- a/helm-charts/k8s-mediaserver/templates/sonarr-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/sonarr-resources.yml
@@ -1,3 +1,8 @@
+{{- if .Values.sabnzbd.enabled }}
+{{- if .Values.transmission.enabled }}
+{{- fail "Transmission and Sabnzbd are mutually exclusive!" }}
+{{- end }}
+{{- end }}
 {{ if .Values.sonarr.enabled }}
 ---
 ### CONFIGMAP

--- a/helm-charts/k8s-mediaserver/templates/sonarr-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/sonarr-resources.yml
@@ -78,13 +78,20 @@ spec:
           volumeMounts: 
             - name: mediaserver-volume
               mountPath: "/config"
-              subPath: "{{ .Values.general.storage.media.config }}/sonarr"
+              subPath: "{{ .Values.general.storage.subPaths.config }}/sonarr"
+{{ if .Values.transmission.enabled }}
             - name: mediaserver-volume
               mountPath: "/downloads"
-              subPath: "{{ .Values.general.storage.media.downloads }}"
+              subPath: "{{ .Values.general.storage.subPaths.transmission }}"
+{{ end }}
+{{ if .Values.sabnzbd.enabled }}
+            - name: mediaserver-volume
+              mountPath: "/downloads"
+              subPath: "{{ .Values.general.storage.subPaths.sabnzbd }}"
+{{ end }}
             - name: mediaserver-volume
               mountPath: "/tv"
-              subPath: "{{ .Values.general.storage.media.tv }}"
+              subPath: "{{ .Values.general.storage.subPaths.tv }}"
           {{- with .Values.sonarr.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/helm-charts/k8s-mediaserver/templates/sonarr-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/sonarr-resources.yml
@@ -51,11 +51,11 @@ spec:
           image: docker.io/ubuntu:groovy
           command: ["/init-sonarr/init-sonarr.sh"]
           volumeMounts:
-            - mountPath: /init-sonarr
+            - mountPath: /init-sonarr 
               name: init-files-sonarr
             - mountPath: /sonarr-config
               name: mediaserver-volume
-              subPath: "config/sonarr"
+              subPath: "{{ .Values.general.storage.media.config }}/sonarr"
           securityContext:
             runAsUser: {{ .Values.general.puid }}
             runAsGroup: {{ .Values.general.pgid }}
@@ -75,16 +75,20 @@ spec:
             - name: sonarr-port
               containerPort: {{ .Values.sonarr.container.port }}
               protocol: TCP
-          volumeMounts:
+          volumeMounts: 
             - name: mediaserver-volume
               mountPath: "/config"
-              subPath: "config/sonarr"
+              subPath: "{{ .Values.general.storage.media.config }}/sonarr"
             - name: mediaserver-volume
               mountPath: "/downloads"
-              subPath: "downloads/transmission"
+              subPath: "{{ .Values.general.storage.media.downloads }}"
             - name: mediaserver-volume
               mountPath: "/tv"
-              subPath: "media/tv"
+              subPath: "{{ .Values.general.storage.media.tv }}"
+          {{- with .Values.sonarr.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: mediaserver-volume
           persistentVolumeClaim:

--- a/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
@@ -151,10 +151,10 @@ spec:
           volumeMounts: 
             - name: mediaserver-volume
               mountPath: "/config"
-              subPath: "{{ .Values.general.storage.media.config }}/transmission"
+              subPath: "{{ .Values.general.storage.subPaths.config }}/transmission"
             - name: mediaserver-volume
               mountPath: "/downloads"
-              subPath: "{{ .Values.general.storage.media.downloads }}"
+              subPath: "{{ .Values.general.storage.subPaths.downloads }}"
           {{- with .Values.transmission.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
@@ -1,3 +1,8 @@
+{{- if .Values.transmission.enabled }}
+{{- if .Values.sabnzbd.enabled }}
+{{- fail "Transmission and Sabnzbd are mutually exclusive!" }}
+{{- end }}
+{{- end }}
 {{- if .Values.transmission.enabled -}}
 ---
 ### CONFIGMAP

--- a/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
@@ -119,10 +119,10 @@ spec:
           command: ["/init-transmission/init-transmission.sh"]
           volumeMounts:
             - mountPath: /init-transmission
-              name: init-files-transmission
+              name: init-files-transmission 
             - mountPath: /transmission-config
               name: mediaserver-volume
-              subPath: "config/transmission"
+              subPath: "{{ .Values.general.storage.media.config }}/transmission"
           securityContext:
             runAsUser: {{ .Values.general.puid }}
             runAsGroup: {{ .Values.general.pgid }}
@@ -148,13 +148,17 @@ spec:
             - name: trans-peer-udp
               containerPort: {{ .Values.transmission.container.port.peer }}
               protocol: UDP
-          volumeMounts:
+          volumeMounts: 
             - name: mediaserver-volume
               mountPath: "/config"
-              subPath: "config/transmission"
+              subPath: "{{ .Values.general.storage.media.config }}/transmission"
             - name: mediaserver-volume
               mountPath: "/downloads"
-              subPath: "downloads/transmission"
+              subPath: "{{ .Values.general.storage.media.downloads }}"
+          {{- with .Values.transmission.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: mediaserver-volume
           persistentVolumeClaim:

--- a/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
@@ -122,7 +122,7 @@ spec:
               name: init-files-transmission 
             - mountPath: /transmission-config
               name: mediaserver-volume
-              subPath: "{{ .Values.general.storage.media.config }}/transmission"
+              subPath: "{{ .Values.general.storage.subPaths.config }}/transmission"
           securityContext:
             runAsUser: {{ .Values.general.puid }}
             runAsGroup: {{ .Values.general.pgid }}

--- a/helm-charts/k8s-mediaserver/values.yaml
+++ b/helm-charts/k8s-mediaserver/values.yaml
@@ -15,6 +15,13 @@ general:
     pvcName: mediaserver-pvc
     size: 5Gi
     pvcStorageClass: []
+    # the path starting from the top level of the pv you're passing. If your share is server.local/share/, then tv is server.local/share/media/tv
+    media:
+      tv: media/tv
+      movies: media/movies
+      downloads: downloads/transmission
+      sabnzbd: downloads/sabnzbd
+      config: config
 
 sonarr:
   enabled: true
@@ -35,6 +42,7 @@ sonarr:
     tls:
       enabled: false
       secretName: ""
+  resources: {}
 
 radarr:
   enabled: true
@@ -55,6 +63,7 @@ radarr:
     tls:
       enabled: false
       secretName: ""
+  resources: {}
   
 jackett:
   enabled: true
@@ -74,6 +83,7 @@ jackett:
     tls:
       enabled: false
       secretName: ""
+  resources: {}
   
 transmission:
   enabled: true
@@ -108,6 +118,7 @@ transmission:
       enabled: false
       username: ""
       password: ""
+  resources: {}
 
 sabnzbd:
   enabled: true
@@ -136,6 +147,7 @@ sabnzbd:
     tls:
       enabled: false
       secretName: ""
+  resources: {}
 
 plex:
   enabled: true
@@ -156,5 +168,10 @@ plex:
     tls:
       enabled: false
       secretName: ""
-
-
+  resources: {}
+  #  limits:
+  #    cpu: 100m
+  #    memory: 100Mi
+  #  requests:
+  #    cpu: 100m
+  #    memory: 100Mi

--- a/helm-charts/k8s-mediaserver/values.yaml
+++ b/helm-charts/k8s-mediaserver/values.yaml
@@ -16,10 +16,10 @@ general:
     size: 5Gi
     pvcStorageClass: []
     # the path starting from the top level of the pv you're passing. If your share is server.local/share/, then tv is server.local/share/media/tv
-    media:
+    subPaths:
       tv: media/tv
       movies: media/movies
-      downloads: downloads/transmission
+      transmission: downloads/transmission
       sabnzbd: downloads/sabnzbd
       config: config
 

--- a/k8s-mediaserver.yml
+++ b/k8s-mediaserver.yml
@@ -3,7 +3,6 @@ kind: K8SMediaserver
 metadata:
   name: k8smediaserver-sample
 spec:
-  # Default values copied from <project_dir>/helm-charts/k8s-mediaserver/values.yaml
   general: 
     ingress_host: k8s-test-loadbalancer.k8s.test
     plex_ingress_host: k8s-plex.k8s.test
@@ -14,10 +13,12 @@ spec:
       pvcName: mediaserver-pvc
       size: 5Gi
       pvcStorageClass: []
-      nfs: false 
-      nfsServer: 
-      nfsPath: 
-
+      subPaths:
+        tv: media/tv
+        movies: media/movies
+        transmission: downloads/transmission
+        sabnzbd: downloads/sabnzbd
+        config: config        
   sonarr:
     enabled: false
     container: 


### PR DESCRIPTION
I added a section under storage to specify where the physical path of every tool should be. I'm keeping the same defaults but allowing the paths to be changed.

```yaml
general:
  storage:
    media:
      tv: media/tv 
      movies: media/movies
      downloads: downloads/transmission
      sabnzbd: downloads/sabnzbd
      config: config
```

I'm also adding a `resources` block to every tool, so you can define limits and requests for each pod, with no resources defined at the start in keeping with other projects.