### PR TITLE
feat(chart): Added a volume with a toggle for each app 

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ The CR is quite simple to configure, and I tried to keep the number of parameter
 | plex.ingress.tls.enabled | If true, tls is enabled | false |
 | plex.ingress.tls.secretName | Name of the secret holding certificates for the secure ingress | "" |
 | plex.resources | Limits and Requests for the container | {} | 
+| plex.volume | If set, Plex will create a PVC for it's config volume, else it will be put on general.storage.subPaths.config | {} |
 
 # Sonarr
 
@@ -124,6 +125,7 @@ The CR is quite simple to configure, and I tried to keep the number of parameter
 | sonarr.ingress.tls.enabled | If true, tls is enabled | false |
 | sonarr.ingress.tls.secretName | Name of the secret holding certificates for the secure ingress | "" | 
 | sonarr.resources | Limits and Requests for the container | {} |
+| sonarr.volume | If set, Sonarr will create a PVC for it's config volume, else it will be put on general.storage.subPaths.config | {} |
 
 # Radarr
 
@@ -141,6 +143,7 @@ The CR is quite simple to configure, and I tried to keep the number of parameter
 | radarr.ingress.tls.enabled | If true, tls is enabled | false |
 | radarr.ingress.tls.secretName | Name of the secret holding certificates for the secure ingress | "" | 
 | radarr.resources | Limits and Requests for the container | {} |
+| radarr.volume | If set, Radarr will create a PVC for it's config volume, else it will be put on general.storage.subPaths.config | {} |
 
 # Jackett
 
@@ -158,6 +161,7 @@ The CR is quite simple to configure, and I tried to keep the number of parameter
 | jackett.ingress.tls.enabled | If true, tls is enabled | false |
 | jackett.ingress.tls.secretName | Name of the secret holding certificates for the secure ingress | "" | 
 | jackett.resources | Limits and Requests for the container | {} |
+| jackett.volume | If set, jackett will create a PVC for it's config volume, else it will be put on general.storage.subPaths.config | {} |
 
 # Transmission
 
@@ -184,6 +188,7 @@ The CR is quite simple to configure, and I tried to keep the number of parameter
 | transmission.config.auth.username | Username for transmission | "" |
 | transmission.config.auth.password | Password for transmission | "" | 
 | transmission.resources | Limits and Requests for the container | {} |
+| transmission.volume | If set, transmission will create a PVC for it's config volume, else it will be put on general.storage.subPaths.config | {} |
 
 # Sabnzbd
 
@@ -206,6 +211,7 @@ The CR is quite simple to configure, and I tried to keep the number of parameter
 | sabnzbd.ingress.tls.enabled | If true, tls is enabled | false |
 | sabnzbd.ingress.tls.secretName | Name of the secret holding certificates for the secure ingress | "" | 
 | sabnzbd.resources | Limits and Requests for the container | {} |
+| sabnzbd.volume | If set, sabnzbd will create a PVC for it's config volume, else it will be put on general.storage.subPaths.config | {} |
 
 ## About the project
 

--- a/helm-charts/k8s-mediaserver/templates/jackett-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/jackett-resources.yml
@@ -53,9 +53,14 @@ spec:
           volumeMounts:
             - mountPath: /init-jackett
               name: init-files-jackett
-            - mountPath: /jackett-config
-              name: mediaserver-volume
+          {{- if .Values.jackett.volume }}
+            - name: {{ .Values.jackett.volume.name }}
+              mountPath: /jackett-config
+          {{- else }}
+            - name: mediaserver-volume
+              mountPath: /jackett-config
               subPath: "{{ .Values.general.storage.subPaths.config }}/jackett/Jackett"
+          {{- end }}
           securityContext:
             runAsUser: {{ .Values.general.puid }}
             runAsGroup: {{ .Values.general.pgid }}
@@ -76,22 +81,32 @@ spec:
               containerPort: {{ .Values.jackett.container.port }}
               protocol: TCP
           volumeMounts:
+          {{- if .Values.jackett.volume }}
+            - name: {{ .Values.jackett.volume.name }}
+              mountPath: /config
+          {{- else }}
             - name: mediaserver-volume
               mountPath: "/config"
               subPath: "{{ .Values.general.storage.subPaths.config }}/jackett"
+          {{- end }}
           {{- with .Values.jackett.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
-        {{ if not .Values.general.storage.customVolume }}
+        {{- if not .Values.general.storage.customVolume }}
         - name: mediaserver-volume
           persistentVolumeClaim:
             claimName: {{ .Values.general.storage.pvcName }}
-        {{ else }}
+        {{- else }}
         - name: mediaserver-volume
           {{- toYaml .Values.general.storage.volumes | nindent 10 }}
-        {{ end }}
+        {{- end }}
+        {{- if .Values.jackett.volume }}
+        - name: {{ .Values.jackett.volume.name }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.jackett.volume.name }}
+        {{- end }}
         - name: init-files-jackett
           configMap:
             defaultMode: 493
@@ -159,7 +174,7 @@ spec:
     - hosts:
         - {{ .Values.general.ingress_host | quote }}
       secretName: {{ .Values.jackett.ingress.tls.secretName }}
-{{ end }}     
+{{ end }}
   ingressClassName: {{ .Values.general.ingress.ingressClassName }}
   rules:
     - host: {{ .Values.general.ingress_host | quote }}
@@ -172,5 +187,5 @@ spec:
                 name: jackett
                 port:
                   number: {{ .Values.jackett.service.port }}
-{{ end }}     
+{{ end }}
 {{ end }}

--- a/helm-charts/k8s-mediaserver/templates/plex-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/plex-resources.yml
@@ -29,14 +29,19 @@ spec:
         app: plex
     spec:
       volumes:
-        {{ if not .Values.general.storage.customVolume }}
+        {{- if not .Values.general.storage.customVolume }}
         - name: mediaserver-volume
           persistentVolumeClaim:
             claimName: {{ .Values.general.storage.pvcName }}
-        {{ else }}
+        {{- else }}
         - name: mediaserver-volume
           {{- toYaml .Values.general.storage.volumes | nindent 10 }}
-        {{ end }}
+        {{- end }}
+        {{- if .Values.plex.volume }}
+        - name: {{ .Values.plex.volume.name }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.plex.volume.name }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           envFrom:
@@ -54,14 +59,19 @@ spec:
               containerPort: {{ .Values.plex.container.port }}
               protocol: TCP
           volumeMounts:
+          {{- if .Values.plex.volume }}
+            - name: {{ .Values.plex.volume.name }}
+              mountPath: /config
+          {{- else }}
             - name: mediaserver-volume
-              mountPath: "/config"
+              mountPath: /config
               subPath: "{{ .Values.general.storage.subPaths.config }}/plex"
+          {{- end }}
             - name: mediaserver-volume
-              mountPath: "/movies"
+              mountPath: /movies
               subPath: "{{ .Values.general.storage.subPaths.movies }}"
             - name: mediaserver-volume
-              mountPath: "/tv"
+              mountPath: /tv
               subPath: "{{ .Values.general.storage.subPaths.tv }}"
           {{- with .Values.plex.resources }}
           resources:
@@ -129,7 +139,7 @@ spec:
     - hosts:
         - {{ .Values.general.plex_ingress_host | quote }}
       secretName: {{ .Values.plex.ingress.tls.secretName }}
-{{ end }}     
+{{ end }}
   ingressClassName: {{ .Values.general.ingress.ingressClassName }}
   rules:
     - host: {{ .Values.general.plex_ingress_host | quote }}
@@ -142,5 +152,5 @@ spec:
                 name: plex
                 port:
                   number: {{ .Values.plex.service.port }}
-{{ end }}     
-{{ end }}     
+{{ end }}
+{{ end }}

--- a/helm-charts/k8s-mediaserver/templates/radarr-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/radarr-resources.yml
@@ -37,6 +37,8 @@ metadata:
   labels:
     {{- include "k8s-mediaserver.labels" . | nindent 4 }}
 spec:
+  strategy:
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:
@@ -53,10 +55,15 @@ spec:
           command: ["/init-radarr/init-radarr.sh"]
           volumeMounts:
             - mountPath: /init-radarr
-              name: init-files-radarr 
-            - mountPath: /radarr-config
-              name: mediaserver-volume
+              name: init-files-radarr
+          {{- if .Values.radarr.volume }}
+            - name: {{ .Values.radarr.volume.name }}
+              mountPath: /radarr-config
+          {{- else }}
+            - name: mediaserver-volume
+              mountPath: /radarr-config
               subPath: "{{ .Values.general.storage.subPaths.config }}/radarr"
+          {{- end }}
           securityContext:
             runAsUser: {{ .Values.general.puid }}
             runAsGroup: {{ .Values.general.pgid }}
@@ -76,10 +83,15 @@ spec:
             - name: radarr-port
               containerPort: {{ .Values.radarr.container.port }}
               protocol: TCP
-          volumeMounts: 
+          volumeMounts:
+          {{- if .Values.radarr.volume }}
+            - name: {{ .Values.radarr.volume.name }}
+              mountPath: /config
+          {{- else }}
             - name: mediaserver-volume
               mountPath: "/config"
               subPath: "{{ .Values.general.storage.subPaths.config }}/radarr"
+          {{- end }}
             - name: mediaserver-volume
               mountPath: "/downloads"
               subPath: "{{ .Values.general.storage.subPaths.downloads }}"
@@ -91,14 +103,19 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
-        {{ if not .Values.general.storage.customVolume }}
+        {{- if not .Values.general.storage.customVolume }}
         - name: mediaserver-volume
           persistentVolumeClaim:
             claimName: {{ .Values.general.storage.pvcName }}
-        {{ else }}
+        {{- else }}
         - name: mediaserver-volume
           {{- toYaml .Values.general.storage.volumes | nindent 10 }}
-        {{ end }}
+        {{- end }}
+        {{- if .Values.radarr.volume }}
+        - name: {{ .Values.radarr.volume.name }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.radarr.volume.name }}
+        {{- end }}
         - name: init-files-radarr
           configMap:
             defaultMode: 493
@@ -165,7 +182,7 @@ spec:
     - hosts:
         - {{ .Values.general.ingress_host | quote }}
       secretName: {{ .Values.radarr.ingress.tls.secretName }}
-{{ end }}     
+{{ end }}
   ingressClassName: {{ .Values.general.ingress.ingressClassName }}
   rules:
     - host: {{ .Values.general.ingress_host | quote }}
@@ -178,5 +195,5 @@ spec:
                 name: radarr
                 port:
                   number: {{ .Values.radarr.service.port }}
-{{ end }}     
-{{ end }}     
+{{ end }}
+{{ end }}

--- a/helm-charts/k8s-mediaserver/templates/sabnzbd-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/sabnzbd-resources.yml
@@ -355,10 +355,15 @@ spec:
           command: ["/init-sabnzbd/init-sabnzbd.sh"]
           volumeMounts:
             - mountPath: /init-sabnzbd
-              name: init-files-sabnzbd 
-            - mountPath: /sabnzbd-config
-              name: mediaserver-volume
+              name: init-files-sabnzbd
+          {{- if .Values.sabnzbd.volume }}
+            - name: {{ .Values.sabnzbd.volume.name }}
+              mountPath: /sabnzbd-config
+          {{- else }}
+            - name: mediaserver-volume
+              mountPath: "/sabnzbd-config"
               subPath: "{{ .Values.general.storage.subPaths.config }}/sabnzbd"
+          {{- end }}
           securityContext:
             runAsUser: {{ .Values.general.puid }}
             runAsGroup: {{ .Values.general.pgid }}
@@ -382,9 +387,14 @@ spec:
               containerPort: {{ .Values.sabnzbd.container.port.https }}
               protocol: TCP
           volumeMounts:
+          {{- if .Values.sabnzbd.volume }}
+            - name: {{ .Values.sabnzbd.volume.name }}
+              mountPath: /config
+          {{- else }}
             - name: mediaserver-volume
               mountPath: "/config"
               subPath: "{{ .Values.general.storage.subPaths.config }}/sabnzbd"
+          {{- end }}
             - name: mediaserver-volume
               mountPath: "/downloads"
               subPath: "{{ .Values.general.storage.subPaths.downloads }}"
@@ -393,14 +403,19 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
-        {{ if not .Values.general.storage.customVolume }}
+        {{- if not .Values.general.storage.customVolume }}
         - name: mediaserver-volume
           persistentVolumeClaim:
             claimName: {{ .Values.general.storage.pvcName }}
-        {{ else }}
+        {{- else }}
         - name: mediaserver-volume
           {{- toYaml .Values.general.storage.volumes | nindent 10 }}
-        {{ end }}
+        {{- end }}
+        {{- if .Values.sabnzbd.volume }}
+        - name: {{ .Values.sabnzbd.volume.name }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.sabnzbd.volume.name }}
+        {{- end }}
         - name: init-files-sabnzbd
           configMap:
             defaultMode: 493
@@ -503,7 +518,7 @@ spec:
     - hosts:
         - {{ .Values.general.ingress_host | quote }}
       secretName: {{ .Values.sabnzbd.ingress.tls.secretName }}
-{{ end }}     
+{{ end }}
   ingressClassName: {{ .Values.general.ingress.ingressClassName }}
   rules:
     - host: {{ .Values.general.ingress_host | quote }}
@@ -516,5 +531,5 @@ spec:
                 name: sabnzbd
                 port:
                   number: {{ .Values.sabnzbd.service.http.port }}
-{{ end }}     
+{{ end }}
 {{ end }}

--- a/helm-charts/k8s-mediaserver/templates/sonarr-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/sonarr-resources.yml
@@ -36,6 +36,8 @@ metadata:
   labels:
     {{- include "k8s-mediaserver.labels" . | nindent 4 }}
 spec:
+  strategy:
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:
@@ -51,11 +53,16 @@ spec:
           image: docker.io/ubuntu:groovy
           command: ["/init-sonarr/init-sonarr.sh"]
           volumeMounts:
-            - mountPath: /init-sonarr 
+            - mountPath: /init-sonarr
               name: init-files-sonarr
-            - mountPath: /sonarr-config
-              name: mediaserver-volume
+          {{- if .Values.sonarr.volume }}
+            - name: {{ .Values.sonarr.volume.name }}
+              mountPath: /sonarr-config
+          {{- else }}
+            - name: mediaserver-volume
+              mountPath: /sonarr-config
               subPath: "{{ .Values.general.storage.subPaths.config }}/sonarr"
+          {{- end }}
           securityContext:
             runAsUser: {{ .Values.general.puid }}
             runAsGroup: {{ .Values.general.pgid }}
@@ -75,10 +82,15 @@ spec:
             - name: sonarr-port
               containerPort: {{ .Values.sonarr.container.port }}
               protocol: TCP
-          volumeMounts: 
+          volumeMounts:
+          {{- if .Values.sonarr.volume }}
+            - name: {{ .Values.sonarr.volume.name }}
+              mountPath: /config
+          {{- else }}
             - name: mediaserver-volume
               mountPath: "/config"
               subPath: "{{ .Values.general.storage.subPaths.config }}/sonarr"
+          {{- end }}
             - name: mediaserver-volume
               mountPath: "/downloads"
               subPath: "{{ .Values.general.storage.subPaths.downloads }}"
@@ -90,14 +102,19 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
-        {{ if not .Values.general.storage.customVolume }}
+        {{- if not .Values.general.storage.customVolume }}
         - name: mediaserver-volume
           persistentVolumeClaim:
             claimName: {{ .Values.general.storage.pvcName }}
-        {{ else }}
+        {{- else }}
         - name: mediaserver-volume
           {{- toYaml .Values.general.storage.volumes | nindent 10 }}
-        {{ end }}
+        {{- end }}
+        {{- if .Values.sonarr.volume }}
+        - name: {{ .Values.sonarr.volume.name }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.sonarr.volume.name }}
+        {{- end }}
         - name: init-files-sonarr
           configMap:
             defaultMode: 493
@@ -163,7 +180,7 @@ spec:
     - hosts:
         - {{ .Values.general.ingress_host | quote }}
       secretName: {{ .Values.sonarr.ingress.tls.secretName }}
-{{ end }}     
+{{ end }}
   ingressClassName: {{ .Values.general.ingress.ingressClassName }}
   rules:
     - host: {{ .Values.general.ingress_host | quote }}
@@ -176,5 +193,5 @@ spec:
                 name: sonarr
                 port:
                   number: {{ .Values.sonarr.service.port }}
-{{ end }}     
+{{ end }}
 {{ end }}

--- a/helm-charts/k8s-mediaserver/templates/storage-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/storage-resources.yml
@@ -1,4 +1,5 @@
-{{ if not .Values.general.storage.customVolume }}
+---
+{{- if not .Values.general.storage.customVolume }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -10,4 +11,160 @@ spec:
     requests:
       storage: {{ .Values.general.storage.size }}
   storageClassName: {{ if (kindIs "invalid" .Values.general.storage.pvcStorageClass) }}""{{- else }}{{ .Values.general.storage.pvcStorageClass | quote }}{{- end }}
-{{ end }}
+{{- end }}
+{{- with .Values.sonarr.volume }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .name }}
+  {{ with .annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{ with .labels }}
+  labels:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .accessModes }}
+  resources:
+    requests:
+      storage: {{ .storage }}
+  storageClassName: {{ .storageClassName }}
+  {{ with .selector }}
+  selector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- with .Values.radarr.volume }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .name }}
+  {{ with .annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{ with .labels }}
+  labels:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .accessModes }}
+  resources:
+    requests:
+      storage: {{ .storage }}
+  storageClassName: {{ .storageClassName }}
+  {{ with .selector }}
+  selector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- with .Values.plex.volume }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .name }}
+  {{ with .annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{ with .labels }}
+  labels:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .accessModes }}
+  resources:
+    requests:
+      storage: {{ .storage }}
+  storageClassName: {{ .storageClassName }}
+  {{ with .selector }}
+  selector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- with .Values.jackett.volume }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .name }}
+  {{ with .annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{ with .labels }}
+  labels:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .accessModes }}
+  resources:
+    requests:
+      storage: {{ .storage }}
+  storageClassName: {{ .storageClassName }}
+  {{ with .selector }}
+  selector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- with .Values.sabnzbd.volume }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .name }}
+  {{ with .annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{ with .labels }}
+  labels:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .accessModes }}
+  resources:
+    requests:
+      storage: {{ .storage }}
+  storageClassName: {{ .storageClassName }}
+  {{ with .selector }}
+  selector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- with .Values.transmission.volume }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .name }}
+  {{ with .annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{ with .labels }}
+  labels:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .accessModes }}
+  resources:
+    requests:
+      storage: {{ .storage }}
+  storageClassName: {{ .storageClassName }}
+  {{ with .selector }}
+  selector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
@@ -119,10 +119,15 @@ spec:
           command: ["/init-transmission/init-transmission.sh"]
           volumeMounts:
             - mountPath: /init-transmission
-              name: init-files-transmission 
-            - mountPath: /transmission-config
-              name: mediaserver-volume
+              name: init-files-transmission
+          {{ if .Values.transmission.volume }}
+            - name: {{ .Values.transmission.volume.name }}
+              mountPath: /transmission-config
+          {{ else }}
+            - name: mediaserver-volume
+              mountPath: "/transmission-config"
               subPath: "{{ .Values.general.storage.subPaths.config }}/transmission"
+          {{ end }}
           securityContext:
             runAsUser: {{ .Values.general.puid }}
             runAsGroup: {{ .Values.general.pgid }}
@@ -148,10 +153,15 @@ spec:
             - name: trans-peer-udp
               containerPort: {{ .Values.transmission.container.port.peer }}
               protocol: UDP
-          volumeMounts: 
+          volumeMounts:
+          {{ if .Values.transmission.volume }}
+            - name: {{ .Values.transmission.volume.name }}
+              mountPath: /config
+          {{ else }}
             - name: mediaserver-volume
               mountPath: "/config"
               subPath: "{{ .Values.general.storage.subPaths.config }}/transmission"
+          {{ end }}
             - name: mediaserver-volume
               mountPath: "/downloads"
               subPath: "{{ .Values.general.storage.subPaths.downloads }}"
@@ -167,6 +177,11 @@ spec:
         {{ else }}
         - name: mediaserver-volume
           {{- toYaml .Values.general.storage.volumes | nindent 10 }}
+        {{ end }}
+        {{ if .Values.transmission.volume }}
+        - name: {{ .Values.transmission.volume.name }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.transmission.volume.name }}
         {{ end }}
         - name: init-files-transmission
           configMap:
@@ -305,7 +320,7 @@ spec:
     - hosts:
         - {{ .Values.general.ingress_host | quote }}
       secretName: {{ .Values.transmission.ingress.tls.secretName }}
-{{ end }}     
+{{ end }}
   ingressClassName: {{ .Values.general.ingress.ingressClassName }}
   rules:
     - host: {{ .Values.general.ingress_host | quote }}
@@ -318,5 +333,5 @@ spec:
                 name: transmission
                 port:
                   number: {{ .Values.transmission.service.utp.port }}
-{{ end }}     
+{{ end }}
 {{ end }}

--- a/helm-charts/k8s-mediaserver/values.yaml
+++ b/helm-charts/k8s-mediaserver/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-general: 
+general:
   ingress_host: k8s-mediaserver.k8s.test
   plex_ingress_host: k8s-plex.k8s.test
   image_tag: latest
@@ -15,7 +15,7 @@ general:
     customVolume: false  #set to true if not using a PVC (must provide volume below)
     pvcName: mediaserver-pvc
     size: 5Gi
-    pvcStorageClass: []
+    pvcStorageClass: ""
     # the path starting from the top level of the pv you're passing. If your share is server.local/share/, then tv is server.local/share/media/tv
     subPaths:
       tv: media/tv
@@ -32,15 +32,15 @@ general:
 
 sonarr:
   enabled: true
-  container: 
+  container:
     nodeSelector: {}
     port: 8989
   service:
     type: ClusterIP
     port: 8989
-    nodePort: 
-    extraLBService: false 
-    # Defines an additional LB service, requires cloud provider service or MetalLB 
+    nodePort:
+    extraLBService: false
+    # Defines an additional LB service, requires cloud provider service or MetalLB
 
   ingress:
     enabled: true
@@ -50,18 +50,28 @@ sonarr:
       enabled: false
       secretName: ""
   resources: {}
+  volume: {}
+    #name: pvc-sonarr-config
+    #storageClassName: longhorn
+    #annotations:
+    #  my-annotation/test: my-value
+    #labels:
+    #  my-label/test: my-other-value
+    #accessModes: ReadWriteOnce
+    #storage: 5Gi
+    #selector: {}
 
 radarr:
   enabled: true
-  container: 
+  container:
     nodeSelector: {}
     port: 7878
   service:
     type: ClusterIP
     port: 7878
-    nodePort: 
-    extraLBService: false 
-    # Defines an additional LB service, requires cloud provider service or MetalLB 
+    nodePort:
+    extraLBService: false
+    # Defines an additional LB service, requires cloud provider service or MetalLB
 
   ingress:
     enabled: true
@@ -71,18 +81,26 @@ radarr:
       enabled: false
       secretName: ""
   resources: {}
-  
+  volume: {}
+    #name: pvc-radarr-config
+    #storageClassName: longhorn
+    #annotations: {}
+    #labels: {}
+    #accessModes: ReadWriteOnce
+    #storage: 5Gi
+    #selector: {}
+
 jackett:
   enabled: true
-  container: 
+  container:
     nodeSelector: {}
     port: 9117
   service:
     type: ClusterIP
     port: 9117
-    nodePort: 
-    extraLBService: false 
-    # Defines an additional LB service, requires cloud provider service or MetalLB 
+    nodePort:
+    extraLBService: false
+    # Defines an additional LB service, requires cloud provider service or MetalLB
   ingress:
     enabled: true
     annotations: {}
@@ -91,27 +109,35 @@ jackett:
       enabled: false
       secretName: ""
   resources: {}
-  
+  volume: {}
+  #  name: pvc-jackett-config
+  #  storageClassName: longhorn
+  #  annotations: {}
+  #  labels: {}
+  #  accessModes: ReadWriteOnce
+  #  storage: 5Gi
+  #  selector: {}
+
 transmission:
   enabled: true
-  container: 
+  container:
     nodeSelector: {}
-    port: 
+    port:
       utp: 9091
       peer: 51413
   service:
     utp:
       type: ClusterIP
       port: 9091
-      nodePort: 
-      # Defines an additional LB service, requires cloud provider service or MetalLB 
+      nodePort:
+      # Defines an additional LB service, requires cloud provider service or MetalLB
       extraLBService: false
     peer:
       type: ClusterIP
       port: 51413
       nodePort:
-      nodePortUDP: 
-      # Defines an additional LB service, requires cloud provider service or MetalLB 
+      nodePortUDP:
+      # Defines an additional LB service, requires cloud provider service or MetalLB
       extraLBService: false
   ingress:
     enabled: true
@@ -121,31 +147,39 @@ transmission:
       enabled: false
       secretName: ""
   config:
-    auth: 
+    auth:
       enabled: false
       username: ""
       password: ""
   resources: {}
+  volume: {}
+  #  name: pvc-transmission-config
+  #  storageClassName: longhorn
+  #  annotations: {}
+  #  labels: {}
+  #  accessModes: ReadWriteOnce
+  #  storage: 5Gi
+  #  selector: {}
 
 sabnzbd:
   enabled: true
-  container: 
+  container:
     nodeSelector: {}
-    port: 
+    port:
       http: 8080
       https: 9090
   service:
     http:
       type: ClusterIP
       port: 8080
-      nodePort: 
-      # Defines an additional LB service, requires cloud provider service or MetalLB 
+      nodePort:
+      # Defines an additional LB service, requires cloud provider service or MetalLB
       extraLBService: false
     https:
       type: ClusterIP
       port: 9090
       nodePort:
-      # Defines an additional LB service, requires cloud provider service or MetalLB 
+      # Defines an additional LB service, requires cloud provider service or MetalLB
       extraLBService: false
   ingress:
     enabled: true
@@ -155,20 +189,28 @@ sabnzbd:
       enabled: false
       secretName: ""
   resources: {}
+  volume: {}
+  #  name: pvc-plex-config
+  #  storageClassName: longhorn
+  #  annotations: {}
+  #  labels: {}
+  #  accessModes: ReadWriteOnce
+  #  storage: 5Gi
+  #  selector: {}
 
 plex:
   enabled: true
   claim: "CHANGEME"
   replicaCount: 1
-  container: 
+  container:
     nodeSelector: {}
     port: 32400
   service:
     type: ClusterIP
     port: 32400
-    nodePort: 
-    # Defines an additional LB service, requires cloud provider service or MetalLB 
-    extraLBService: false 
+    nodePort:
+    # Defines an additional LB service, requires cloud provider service or MetalLB
+    extraLBService: false
   ingress:
     enabled: true
     annotations: {}
@@ -182,3 +224,11 @@ plex:
   #  requests:
   #    cpu: 100m
   #    memory: 100Mi
+  volume: {}
+  #  name: pvc-plex-config
+  #  storageClassName: longhorn
+  #  annotations: {}
+  #  labels: {}
+  #  accessModes: ReadWriteOnce
+  #  storage: 5Gi
+  #  selector: {}

--- a/k8s-mediaserver.yml
+++ b/k8s-mediaserver.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: charts.kubealex.com/v1
 kind: K8SMediaserver
 metadata:
@@ -9,14 +10,18 @@ spec:
     ingress:
       ingressClassName: ""
     ingress_host: k8s-mediaserver.k8s.test
-    pgid: 1000
     plex_ingress_host: k8s-plex.k8s.test
+    # UID to run the process with
     puid: 1000
+    # GID to run the process with
+    pgid: 1000
+    # Persistent storage selections and pathing
     storage:
-      customVolume: false
+      customVolume: false  # set to true if not using a PVC (must provide volume below)
       pvcName: mediaserver-pvc
-      pvcStorageClass: []
       size: 5Gi
+      pvcStorageClass: ""
+      # the path starting from the top level of the pv you're passing. If your share is server.local/share/, then tv is server.local/share/media/tv
       subPaths:
         config: config
         downloads: downloads
@@ -24,137 +29,210 @@ spec:
         sabnzbd: sabnzbd
         transmission: transmission
         tv: media/tv
+
       volumes: {}
-  jackett:
-    container:
-      nodeSelector: {}
-      port: 9117
-    enabled: true
-    ingress:
-      annotations: {}
-      enabled: true
-      path: /jackett
-      tls:
-        enabled: false
-        secretName: ""
-    resources: {}
-    service:
-      extraLBService: false
-      nodePort: null
-      port: 9117
-      type: ClusterIP
-  plex:
-    claim: CHANGEME
-    container:
-      nodeSelector: {}
-      port: 32400
-    enabled: true
-    ingress:
-      annotations: {}
-      enabled: true
-      tls:
-        enabled: false
-        secretName: ""
-    replicaCount: 1
-    resources: {}
-    service:
-      extraLBService: false
-      nodePort: null
-      port: 32400
-      type: ClusterIP
-  radarr:
-    container:
-      nodeSelector: {}
-      port: 7878
-    enabled: true
-    ingress:
-      annotations: {}
-      enabled: true
-      path: /radarr
-      tls:
-        enabled: false
-        secretName: ""
-    resources: {}
-    service:
-      extraLBService: false
-      nodePort: null
-      port: 7878
-      type: ClusterIP
-  sabnzbd:
-    container:
-      nodeSelector: {}
-      port:
-        http: 8080
-        https: 9090
-    enabled: true
-    ingress:
-      annotations: {}
-      enabled: true
-      path: /sabnzbd
-      tls:
-        enabled: false
-        secretName: ""
-    resources: {}
-    service:
-      http:
-        extraLBService: false
-        nodePort: null
-        port: 8080
-        type: ClusterIP
-      https:
-        extraLBService: false
-        nodePort: null
-        port: 9090
-        type: ClusterIP
+      #  hostPath:
+      #    path: /mnt/share
+
   sonarr:
+    enabled: true
     container:
       nodeSelector: {}
       port: 8989
-    enabled: true
+    service:
+      type: ClusterIP
+      port: 8989
+      nodePort:
+      extraLBService: false
+      # Defines an additional LB service, requires cloud provider service or MetalLB
+
     ingress:
-      annotations: {}
       enabled: true
+      annotations: {}
       path: /sonarr
       tls:
         enabled: false
         secretName: ""
     resources: {}
-    service:
-      extraLBService: false
-      nodePort: null
-      port: 8989
-      type: ClusterIP
-  transmission:
-    config:
-      auth:
-        enabled: false
-        password: ""
-        username: ""
+    volume: {}
+    # name: pvc-sonarr-config
+    # storageClassName: longhorn
+    # annotations:
+    #   my-annotation/test: my-value
+    # labels:
+    #   my-label/test: my-other-value
+    # accessModes: ReadWriteOnce
+    # storage: 5Gi
+    # selector: {}
+
+  radarr:
+    enabled: true
     container:
       nodeSelector: {}
-      port:
-        peer: 51413
-        utp: 9091
-    enabled: true
+      port: 7878
+    service:
+      type: ClusterIP
+      port: 7878
+      nodePort:
+      extraLBService: false
+      # Defines an additional LB service, requires cloud provider service or MetalLB
+
     ingress:
-      annotations: {}
       enabled: true
-      path: /transmission
+      annotations: {}
+      path: /radarr
       tls:
         enabled: false
         secretName: ""
     resources: {}
+    volume: {}
+    # name: pvc-radarr-config
+    # storageClassName: longhorn
+    # annotations: {}
+    # labels: {}
+    # accessModes: ReadWriteOnce
+    # storage: 5Gi
+    # selector: {}
+    
+  jackett:
+    enabled: true
+    container:
+      nodeSelector: {}
+      port: 9117
     service:
-      peer:
-        extraLBService: false
-        nodePort: null
-        nodePortUDP: null
-        port: 51413
-        type: ClusterIP
+      type: ClusterIP
+      port: 9117
+      nodePort:
+      extraLBService: false
+      # Defines an additional LB service, requires cloud provider service or MetalLB
+    ingress:
+      enabled: true
+      annotations: {}
+      path: /jackett
+      tls:
+        enabled: false
+        secretName: ""
+    resources: {}
+    volume: {}
+    #  name: pvc-jackett-config
+    #  storageClassName: longhorn
+    #  annotations: {}
+    #  labels: {}
+    #  accessModes: ReadWriteOnce
+    #  storage: 5Gi
+    #  selector: {}
+
+  transmission:
+    enabled: true
+    container:
+      nodeSelector: {}
+      port:
+        utp: 9091
+        peer: 51413
+    service:
       utp:
-        extraLBService: false
-        nodePort: null
-        port: 9091
         type: ClusterIP
-  
-  
+        port: 9091
+        nodePort:
+        # Defines an additional LB service, requires cloud provider service or MetalLB
+        extraLBService: false
+      peer:
+        type: ClusterIP
+        port: 51413
+        nodePort:
+        nodePortUDP:
+        # Defines an additional LB service, requires cloud provider service or MetalLB
+        extraLBService: false
+    ingress:
+      enabled: true
+      annotations: {}
+      path: /transmission
+      tls:
+        enabled: false
+        secretName: ""
+    config:
+      auth:
+        enabled: false
+        username: ""
+        password: ""
+    resources: {}
+    volume: {}
+    #  name: pvc-transmission-config
+    #  storageClassName: longhorn
+    #  annotations: {}
+    #  labels: {}
+    #  accessModes: ReadWriteOnce
+    #  storage: 5Gi
+    #  selector: {}
+
+  sabnzbd:
+    enabled: true
+    container:
+      nodeSelector: {}
+      port:
+        http: 8080
+        https: 9090
+    service:
+      http:
+        type: ClusterIP
+        port: 8080
+        nodePort:
+        # Defines an additional LB service, requires cloud provider service or MetalLB
+        extraLBService: false
+      https:
+        type: ClusterIP
+        port: 9090
+        nodePort:
+        # Defines an additional LB service, requires cloud provider service or MetalLB
+        extraLBService: false
+    ingress:
+      enabled: true
+      annotations: {}
+      path: /sabnzbd
+      tls:
+        enabled: false
+        secretName: ""
+    resources: {}
+    volume: {}
+    #  name: pvc-plex-config
+    #  storageClassName: longhorn
+    #  annotations: {}
+    #  labels: {}
+    #  accessModes: ReadWriteOnce
+    #  storage: 5Gi
+    #  selector: {}
+
+  plex:
+    enabled: true
+    claim: "CHANGEME"
+    replicaCount: 1
+    container:
+      nodeSelector: {}
+      port: 32400
+    service:
+      type: ClusterIP
+      port: 32400
+      nodePort:
+      # Defines an additional LB service, requires cloud provider service or MetalLB
+      extraLBService: false
+    ingress:
+      enabled: true
+      annotations: {}
+      tls:
+        enabled: false
+        secretName: ""
+    resources: {}
+    #  limits:
+    #    cpu: 100m
+    #    memory: 100Mi
+    #  requests:
+    #    cpu: 100m
+    #    memory: 100Mi
+    volume: {}
+    #  name: pvc-plex-config
+    #  storageClassName: longhorn
+    #  annotations: {}
+    #  labels: {}
+    #  accessModes: ReadWriteOnce
+    #  storage: 5Gi
+    #  selector: {}


### PR DESCRIPTION
Fixes #26 

If the volumes are not specified, the default is to put everything on the current storage (where the media is). Each tool can create a persistentVolumeClaim if it's `volume` field is set.

For example to add a config volume for Sonarr:

```yaml
sonarr:
  enabled: true
  # < ... >
  volume:
    name: pvc-sonarr-config
    storageClassName: longhorn
    annotations:
      my-annotation/test: my-value
    labels:
      my-label/test: my-other-value
    accessModes: ReadWriteOnce
    storage: 5Gi
    selector: {}
```


