### PR TITLE
add ingressClassName

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The CR is quite simple to configure, and I tried to keep the number of parameter
 | general.storage.subPaths.sabnzbd | Default subpath for sabnzbd downloads on used storage | general.storage.subPaths.downloads/sabnzbd |
 | general.storage.subPaths.config | Default subpath for all config files on used storage | config |
 | general.storage.volumes | Supply custom volume to be mounted for all services | {} |
+| general.ingress.ingressClassName | Reference an IngressClass resource that contains additional Ingress configuration | "" |
 
 # Plex
 

--- a/helm-charts/k8s-mediaserver/templates/jackett-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/jackett-resources.yml
@@ -160,6 +160,7 @@ spec:
         - {{ .Values.general.ingress_host | quote }}
       secretName: {{ .Values.jackett.ingress.tls.secretName }}
 {{ end }}     
+  ingressClassName: {{ .Values.general.ingress.ingressClassName }}
   rules:
     - host: {{ .Values.general.ingress_host | quote }}
       http:

--- a/helm-charts/k8s-mediaserver/templates/plex-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/plex-resources.yml
@@ -130,6 +130,7 @@ spec:
         - {{ .Values.general.plex_ingress_host | quote }}
       secretName: {{ .Values.plex.ingress.tls.secretName }}
 {{ end }}     
+  ingressClassName: {{ .Values.general.ingress.ingressClassName }}
   rules:
     - host: {{ .Values.general.plex_ingress_host | quote }}
       http:

--- a/helm-charts/k8s-mediaserver/templates/radarr-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/radarr-resources.yml
@@ -166,6 +166,7 @@ spec:
         - {{ .Values.general.ingress_host | quote }}
       secretName: {{ .Values.radarr.ingress.tls.secretName }}
 {{ end }}     
+  ingressClassName: {{ .Values.general.ingress.ingressClassName }}
   rules:
     - host: {{ .Values.general.ingress_host | quote }}
       http:

--- a/helm-charts/k8s-mediaserver/templates/sabnzbd-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/sabnzbd-resources.yml
@@ -504,6 +504,7 @@ spec:
         - {{ .Values.general.ingress_host | quote }}
       secretName: {{ .Values.sabnzbd.ingress.tls.secretName }}
 {{ end }}     
+  ingressClassName: {{ .Values.general.ingress.ingressClassName }}
   rules:
     - host: {{ .Values.general.ingress_host | quote }}
       http:

--- a/helm-charts/k8s-mediaserver/templates/sonarr-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/sonarr-resources.yml
@@ -164,6 +164,7 @@ spec:
         - {{ .Values.general.ingress_host | quote }}
       secretName: {{ .Values.sonarr.ingress.tls.secretName }}
 {{ end }}     
+  ingressClassName: {{ .Values.general.ingress.ingressClassName }}
   rules:
     - host: {{ .Values.general.ingress_host | quote }}
       http:

--- a/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
@@ -306,6 +306,7 @@ spec:
         - {{ .Values.general.ingress_host | quote }}
       secretName: {{ .Values.transmission.ingress.tls.secretName }}
 {{ end }}     
+  ingressClassName: {{ .Values.general.ingress.ingressClassName }}
   rules:
     - host: {{ .Values.general.ingress_host | quote }}
       http:

--- a/helm-charts/k8s-mediaserver/values.yaml
+++ b/helm-charts/k8s-mediaserver/values.yaml
@@ -27,6 +27,8 @@ general:
     volumes: {}
     #  hostPath:
     #    path: /mnt/share
+  ingress:
+    ingressClassName: ""
 
 sonarr:
   enabled: true


### PR DESCRIPTION
On my bare metal k8s with metallb and nginx-ingress-controller I don't want to use the extraLBService which uses additional ip-addresses but instead I want to use the nginx-ingress-controller (which has a LB ip-address assigned by metallb). By adding "ingressClassName" to the ingress I can specify the ingressClassName (e.g. "ingressClassName: nginx") and exposes the apps by their configured rules host and path.