### PR TITLE
feat(workflow): add repo tagging and docker image tag and release wor…

### DIFF
--- a/.github/workflows/bump-repo-version.yml
+++ b/.github/workflows/bump-repo-version.yml
@@ -1,0 +1,16 @@
+name: Bump version
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Bump version and push tag
+        uses: hennejg/github-tag-action@v4.1.jh1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-release-image.yml
+++ b/.github/workflows/docker-release-image.yml
@@ -1,0 +1,49 @@
+name: ci
+on: [push]
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            docker.io/${{ github.repository }}
+            ghcr.io/${{ github.repository }}
+            quay.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+          flavor: |
+            latest=true
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to Red Hat Quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        env:
+          DOCKER_BUILDKIT: 1
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Fixes #38  : All commits now generate tagged docker images. The images are pushed to ghcr, quay.io and dockerhub. To help with this, we're moving to fully automated semver and adding a version to every merged pull request on master. 

# For the docker builds and pushes:

You'll need to add variable to this repo's secrets.
`QUAY_USERNAME`
`QUAY_PASSWORD` (generate a token for this)
`DOCKER_USERNAME`
`DOCKER_PASSWORD` (generate a token for this) 

# For the semver:

How it works is that it automatically bumps bugfix versions on every commit, but certain keywords in commits (`feat(...)` and `perf(...)`) will trigger major and minor versions. For example this PR would raise the current version from `0.6.1` to `0.7.0` because it has `feat(workflow)` in it.

Before merging this you'll need to add the tag `v0.6.1` to the current commit on the master branch. The next versions will be done automatically and we can do away with the version in the dockerfile.