### PR TITLE
Adding instructions for using pre-exisiting NFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,29 @@ With default settings, your applications will run in these paths:
 
     http://k8s-plex.k8s.test/
 
+## Using a cluster-external NFS server
+This assumes that you have an already pre-configured NFS server set up on your network that is accessible from all nodes. If it is not accessible by all nodes, pods will not enter ready state when scheduled on nodes that do not have NFS access. 
+
+To add an NFS volume to each resource, create a `my-values.yaml` file and add the below. You should change the `server:` and `path:` values to match your NFS.
+
+``` yaml
+general:
+  storage:
+    customVolume: true
+  volumes:
+    nfs:
+      server: {SERVER-IP}
+      path: /mount/path/on/nfs/server/
+```
+With this value saved in the top level directory of this repo, running the below will add the resources to your cluster, under the helm release name `k8s-mediaserver`
+
+``` bash
+helm install -f my-values.yaml k8s-mediaserver ./helm-charts/k8s-mediaserver/
+```
+
+This is eqiuvalent to running `mount {SERVER-IP}:/mount/path/on/nfs/server ...` in each container, where `...` is different per resouce, as defined in the templatesdirectory (for each resource).
+In addition to the above, you should also edit your subpaths so that they when they are appended to your `path:` specified in `values.yaml`, they map to the directories you intend.
+
 ## The mediaserver CR
 The CR is quite simple to configure, and I tried to keep the number of parameters low to avoid confusion, but still letting some customization to fit the resource inside your cluster.
 

--- a/README.md
+++ b/README.md
@@ -1,32 +1,41 @@
 ## k8s-mediaserver-operator - Your all-in-one resource for your media needs!
 
-I am so happy to announce the first release of the **k8s-mediaserver-operator**, a project that mixes up some of the mainstream tools for your media needs.
+I am so happy to announce the first release of the **k8s-mediaserver-operator**, a project that mixes up some of the
+mainstream tools for your media needs.
 
-The Custom Resource that is implemented, allows you to create a fully working and complete media server on #kubernetes, based on:
+The Custom Resource that is implemented, allows you to create a fully working and complete media server on #kubernetes,
+based on:
 
-[Plex Media Server](https://www.plex.tv/ "Plex Media Server") - A complete and fully funtional mediaserver that allows you to render in a webUI your movies, TV Series, podcasts, video streams. 
+[Plex Media Server](https://www.plex.tv/ "Plex Media Server") - A complete and fully funtional mediaserver that allows
+you to render in a webUI your movies, TV Series, podcasts, video streams.
 
-[Sonarr](https://sonarr.tv/ "Sonarr") - A TV series and show tracker, that allows the integration with download managers for searching and retrieving TV Series, organizing them, schedule notifications when an episode comes up and much more.
+[Sonarr](https://sonarr.tv/ "Sonarr") - A TV series and show tracker, that allows the integration with download managers
+for searching and retrieving TV Series, organizing them, schedule notifications when an episode comes up and much more.
 
 [Radarr](https://radarr.video/ "Radarr") - The same a **Sonarr**, but for movies!
 
-[Jackett](https://github.com/Jackett/Jackett "Jackett") - An API interface that keeps easy your life interacting with trackers for torrents.
+[Jackett](https://github.com/Jackett/Jackett "Jackett") - An API interface that keeps easy your life interacting with
+trackers for torrents.
 
 [Transmission](https://transmissionbt.com/ "Transmission") - A fast, easy and reliable torrent client.
 
 [Sabnzbd](https://sabnzbd.org/ "Sabnzbd") - A free and easy binary newsreader.
 
-All container images used by the operator are from [linuxserver](https://github.com/linuxserver) - [linuxserver.io](https://www.linuxserver.io/ "linuxserver.io")
+All container images used by the operator are from [linuxserver](https://github.com/linuxserver)
+- [linuxserver.io](https://www.linuxserver.io/ "linuxserver.io")
 
 Each of the components can be **enabled** or **disabled** if you already have something in place in your lab!
 
 ## Introduction
 
-I started working on this project because I was tired of using the 'containerized' version with docker/podman-compose, and I wanted to experiment a bit both with helm and operators.
+I started working on this project because I was tired of using the 'containerized' version with docker/podman-compose,
+and I wanted to experiment a bit both with helm and operators.
 
-It is quite simple to use, and very minimalistic, with customizations that are strictly related to usability and access, rather than complex customizations, even if, maybe in the future, we could add it!
+It is quite simple to use, and very minimalistic, with customizations that are strictly related to usability and access,
+rather than complex customizations, even if, maybe in the future, we could add it!
 
-Each container has its *init container* in order to initialize configurations on the PV before starting the actual pod and avoid to restart the pods.
+Each container has its *init container* in order to initialize configurations on the PV before starting the actual pod
+and avoid to restart the pods.
 
 ## QuickStart
 
@@ -35,16 +44,16 @@ The operator and the CR are already configured with some defaults settings to ma
 All you need is:
 
 - A namespace where you want to put your CR and all the pods that will spawn
-- Being able to provision an RWX PV where to store configurations, downloads, and all related stuff (suggested > 200GB). 
-Persistent Volume **or** StorageClasses for dynamically provisioned volumes are **REQUIRED**
+- Being able to provision an RWX PV where to store configurations, downloads, and all related stuff (suggested > 200GB).
+  Persistent Volume **or** StorageClasses for dynamically provisioned volumes are **REQUIRED**
 
 First install the CRD and the operator:
 
-AMD/Intel: 
+AMD/Intel:
 
     kubectl apply -f k8s-mediaserver-operator.yml
 
-ARM - Raspberry Pi: 
+ARM - Raspberry Pi:
 
     kubectl apply -f k8s-mediaserver-operator-arm64.yml
 
@@ -64,9 +73,12 @@ With default settings, your applications will run in these paths:
     http://k8s-plex.k8s.test/
 
 ## Using a cluster-external NFS server
-This assumes that you have a pre-configured NFS server set up on your network that is accessible from all nodes. If it is not accessible by all nodes, pods will not enter ready state when scheduled on nodes that do not have NFS access. 
 
-To add an NFS volume to each resource, create a `my-values.yaml` file and add the below. You should change the `server:` and `path:` values to match your NFS.
+This assumes that you have a pre-configured NFS server set up on your network that is accessible from all nodes. If it
+is not accessible by all nodes, pods will not enter ready state when scheduled on nodes that do not have NFS access.
+
+To add an NFS volume to each resource, create a `my-values.yaml` file and add the below. You should change the `server:`
+and `path:` values to match your NFS.
 
 ``` yaml
 general:
@@ -77,163 +89,169 @@ general:
       server: {SERVER-IP}
       path: /mount/path/on/nfs/server/
 ```
-With this value saved in the top level directory of this repo, running the below will add the resources to your cluster, under the helm release name `k8s-mediaserver`
+
+With this value saved in the top level directory of this repo, running the below will add the resources to your cluster,
+under the helm release name `k8s-mediaserver`
 
 ``` bash
 helm install -f my-values.yaml k8s-mediaserver ./helm-charts/k8s-mediaserver/
 ```
 
-This is eqiuvalent to running `mount {SERVER-IP}:/mount/path/on/nfs/server ...` in each container, where `...` is different per resource, as defined in the templates directory (for each resource).
-In addition to the above, you should also edit your subpaths so that they when they are appended to your `path:` specified in `values.yaml`, they map to the directories you intend.
+This is equivalent to running `mount {SERVER-IP}:/mount/path/on/nfs/server ...` in each container, where `...` is
+different per resource, as defined in the templates directory (for each resource).
+In addition to the above, you should also edit your subpaths so that they when they are appended to your `path:`
+specified in `values.yaml`, they map to the directories you intend.
 
 ## The mediaserver CR
-The CR is quite simple to configure, and I tried to keep the number of parameters low to avoid confusion, but still letting some customization to fit the resource inside your cluster.
+
+The CR is quite simple to configure, and I tried to keep the number of parameters low to avoid confusion, but still
+letting some customization to fit the resource inside your cluster.
 
 # General config
 
-| Config path | Meaning | Default | 
-| ------------ | ------------ | ------------ |
-| general.ingress_host | The hostname to use in ingress definition, this will be the hostname where the applications will be exposed  | k8s-mediaserver.k8s.test |
-| general.plex_ingress_host | The hostname to use for **PLEX** as it must be exposed on a / dedicated path  | k8s-plex.k8s.test |
-| general.image_tag | The name of the image tag (arm32v7-latest, arm64v8-latest, development)  | latest |
-| general.pgid | The GID for the process | 1000 |
-| general.puid | The UID for the process | 1000 |
-| general.nodeSelector | Node Selector for all the pods | {} |
-| general.storage.customVolume | Flag if you want to supply your own volume and not use a PVC | false |
-| general.storage.pvcName  | Name of the persistenVolumeClaim configured in deployments | mediaserver-pvc |
-| general.storage.pvcStorageClass  | Specifies a storageClass for the PVC | "" |
-| general.storage.size | Size of the persistenVolume | 50Gi |
-| general.storage.subPaths.tv | Default subpath for tv series folder on used storage | media/tv |
-| general.storage.subPaths.movies | Default subpath for movies folder on used storage | media/movies |
-| general.storage.subPaths.downloads | Default root path for downloads for both sabnzbd and transmission on used storage | downloads |
-| general.storage.subPaths.transmission | Default subpath for transmission downloads on used storage | general.storage.subPaths.downloads/transmission |
-| general.storage.subPaths.sabnzbd | Default subpath for sabnzbd downloads on used storage | general.storage.subPaths.downloads/sabnzbd |
-| general.storage.subPaths.config | Default subpath for all config files on used storage | config |
-| general.storage.volumes | Supply custom volume to be mounted for all services | {} |
-| general.ingress.ingressClassName | Reference an IngressClass resource that contains additional Ingress configuration | "" |
+| Config path                           | Meaning                                                                                                     | Default                                         | 
+|---------------------------------------|-------------------------------------------------------------------------------------------------------------|-------------------------------------------------|
+| general.ingress_host                  | The hostname to use in ingress definition, this will be the hostname where the applications will be exposed | k8s-mediaserver.k8s.test                        |
+| general.plex_ingress_host             | The hostname to use for **PLEX** as it must be exposed on a / dedicated path                                | k8s-plex.k8s.test                               |
+| general.image_tag                     | The name of the image tag (arm32v7-latest, arm64v8-latest, development)                                     | latest                                          |
+| general.pgid                          | The GID for the process                                                                                     | 1000                                            |
+| general.puid                          | The UID for the process                                                                                     | 1000                                            |
+| general.nodeSelector                  | Node Selector for all the pods                                                                              | {}                                              |
+| general.storage.customVolume          | Flag if you want to supply your own volume and not use a PVC                                                | false                                           |
+| general.storage.pvcName               | Name of the persistenVolumeClaim configured in deployments                                                  | mediaserver-pvc                                 |
+| general.storage.pvcStorageClass       | Specifies a storageClass for the PVC                                                                        | ""                                              |
+| general.storage.size                  | Size of the persistenVolume                                                                                 | 50Gi                                            |
+| general.storage.subPaths.tv           | Default subpath for tv series folder on used storage                                                        | media/tv                                        |
+| general.storage.subPaths.movies       | Default subpath for movies folder on used storage                                                           | media/movies                                    |
+| general.storage.subPaths.downloads    | Default root path for downloads for both sabnzbd and transmission on used storage                           | downloads                                       |
+| general.storage.subPaths.transmission | Default subpath for transmission downloads on used storage                                                  | general.storage.subPaths.downloads/transmission |
+| general.storage.subPaths.sabnzbd      | Default subpath for sabnzbd downloads on used storage                                                       | general.storage.subPaths.downloads/sabnzbd      |
+| general.storage.subPaths.config       | Default subpath for all config files on used storage                                                        | config                                          |
+| general.storage.volumes               | Supply custom volume to be mounted for all services                                                         | {}                                              |
+| general.ingress.ingressClassName      | Reference an IngressClass resource that contains additional Ingress configuration                           | ""                                              |
 
 # Plex
 
-| Config path | Meaning | Default | 
-| ------------ | ------------ | ------------ |
-| plex.enabled | Flag if you want to enable plex | true | 
-| plex.claim | **IMPORTANT** Token from your account, needed to claim the server | CHANGEME |
-| plex.replicaCount | Number of replicas serving plex | 1 | 
-| plex.container.port | The port in use by the container | 32400 | 
-| plex.service.type | The kind of Service (ClusterIP/NodePort/LoadBalancer) | ClusterIP |
-| plex.service.port | The port assigned to the service | 32400 |
-| plex.service.nodePort | In case of service.type NodePort, the nodePort to use | "" |
-| plex.service.extraLBService | If true, creates an additional LoadBalancer service with '-lb' suffix (requires a cloud provider or metalLB) | false | 
-| plex.ingress.enabled | If true, creates the ingress resource for the application | true |
-| plex.ingress.annotations | Additional field for annotations, if needed | {} |
-| plex.ingress.path | The path where the application is exposed | /plex |
-| plex.ingress.tls.enabled | If true, tls is enabled | false |
-| plex.ingress.tls.secretName | Name of the secret holding certificates for the secure ingress | "" |
-| plex.resources | Limits and Requests for the container | {} | 
+| Config path                 | Meaning                                                                                                      | Default   | 
+|-----------------------------|--------------------------------------------------------------------------------------------------------------|-----------|
+| plex.enabled                | Flag if you want to enable plex                                                                              | true      | 
+| plex.claim                  | **IMPORTANT** Token from your account, needed to claim the server                                            | CHANGEME  |
+| plex.replicaCount           | Number of replicas serving plex                                                                              | 1         | 
+| plex.container.port         | The port in use by the container                                                                             | 32400     | 
+| plex.service.type           | The kind of Service (ClusterIP/NodePort/LoadBalancer)                                                        | ClusterIP |
+| plex.service.port           | The port assigned to the service                                                                             | 32400     |
+| plex.service.nodePort       | In case of service.type NodePort, the nodePort to use                                                        | ""        |
+| plex.service.extraLBService | If true, creates an additional LoadBalancer service with '-lb' suffix (requires a cloud provider or metalLB) | false     | 
+| plex.ingress.enabled        | If true, creates the ingress resource for the application                                                    | true      |
+| plex.ingress.annotations    | Additional field for annotations, if needed                                                                  | {}        |
+| plex.ingress.path           | The path where the application is exposed                                                                    | /plex     |
+| plex.ingress.tls.enabled    | If true, tls is enabled                                                                                      | false     |
+| plex.ingress.tls.secretName | Name of the secret holding certificates for the secure ingress                                               | ""        |
+| plex.resources              | Limits and Requests for the container                                                                        | {}        | 
 
 # Sonarr
 
-| Config path | Meaning | Default | 
-| ------------ | ------------ | ------------ |
-| sonarr.enabled | Flag if you want to enable sonarr | true | 
-| sonarr.container.port | The port in use by the container | 8989 | 
-| sonarr.service.type | The kind of Service (ClusterIP/NodePort/LoadBalancer) | ClusterIP |
-| sonarr.service.port | The port assigned to the service | 8989 |
-| sonarr.service.nodePort | In case of service.type NodePort, the nodePort to use | "" |
-| sonarr.service.extraLBService | If true, creates an additional LoadBalancer service with '-lb' suffix (requires a cloud provider or metalLB) | false 
-| sonarr.ingress.enabled | If true, creates the ingress resource for the application | true |
-| sonarr.ingress.annotations | Additional field for annotations, if needed | {} |
-| sonarr.ingress.path | The path where the application is exposed | /sonarr |
-| sonarr.ingress.tls.enabled | If true, tls is enabled | false |
-| sonarr.ingress.tls.secretName | Name of the secret holding certificates for the secure ingress | "" | 
-| sonarr.resources | Limits and Requests for the container | {} |
+| Config path                   | Meaning                                                                                                      | Default   | 
+|-------------------------------|--------------------------------------------------------------------------------------------------------------|-----------|
+| sonarr.enabled                | Flag if you want to enable sonarr                                                                            | true      | 
+| sonarr.container.port         | The port in use by the container                                                                             | 8989      | 
+| sonarr.service.type           | The kind of Service (ClusterIP/NodePort/LoadBalancer)                                                        | ClusterIP |
+| sonarr.service.port           | The port assigned to the service                                                                             | 8989      |
+| sonarr.service.nodePort       | In case of service.type NodePort, the nodePort to use                                                        | ""        |
+| sonarr.service.extraLBService | If true, creates an additional LoadBalancer service with '-lb' suffix (requires a cloud provider or metalLB) | false     |
+| sonarr.ingress.enabled        | If true, creates the ingress resource for the application                                                    | true      |
+| sonarr.ingress.annotations    | Additional field for annotations, if needed                                                                  | {}        |
+| sonarr.ingress.path           | The path where the application is exposed                                                                    | /sonarr   |
+| sonarr.ingress.tls.enabled    | If true, tls is enabled                                                                                      | false     |
+| sonarr.ingress.tls.secretName | Name of the secret holding certificates for the secure ingress                                               | ""        | 
+| sonarr.resources              | Limits and Requests for the container                                                                        | {}        |
 
 # Radarr
 
-| Config path | Meaning | Default | 
-| ------------ | ------------ | ------------ |
-| radarr.enabled | Flag if you want to enable radarr | true | 
-| radarr.container.port | The port in use by the container | 7878 | 
-| radarr.service.type | The kind of Service (ClusterIP/NodePort/LoadBalancer) | ClusterIP |
-| radarr.service.port | The port assigned to the service | 7878 |
-| radarr.service.nodePort | In case of service.type NodePort, the nodePort to use | "" |
-| radarr.service.extraLBService | If true, creates an additional LoadBalancer service with '-lb' suffix (requires a cloud provider or metalLB) | false | 
-| radarr.ingress.enabled | If true, creates the ingress resource for the application | true |
-| radarr.ingress.annotations | Additional field for annotations, if needed | {} |
-| radarr.ingress.path | The path where the application is exposed | /radarr  |
-| radarr.ingress.tls.enabled | If true, tls is enabled | false |
-| radarr.ingress.tls.secretName | Name of the secret holding certificates for the secure ingress | "" | 
-| radarr.resources | Limits and Requests for the container | {} |
+| Config path                   | Meaning                                                                                                      | Default   | 
+|-------------------------------|--------------------------------------------------------------------------------------------------------------|-----------|
+| radarr.enabled                | Flag if you want to enable radarr                                                                            | true      | 
+| radarr.container.port         | The port in use by the container                                                                             | 7878      | 
+| radarr.service.type           | The kind of Service (ClusterIP/NodePort/LoadBalancer)                                                        | ClusterIP |
+| radarr.service.port           | The port assigned to the service                                                                             | 7878      |
+| radarr.service.nodePort       | In case of service.type NodePort, the nodePort to use                                                        | ""        |
+| radarr.service.extraLBService | If true, creates an additional LoadBalancer service with '-lb' suffix (requires a cloud provider or metalLB) | false     | 
+| radarr.ingress.enabled        | If true, creates the ingress resource for the application                                                    | true      |
+| radarr.ingress.annotations    | Additional field for annotations, if needed                                                                  | {}        |
+| radarr.ingress.path           | The path where the application is exposed                                                                    | /radarr   |
+| radarr.ingress.tls.enabled    | If true, tls is enabled                                                                                      | false     |
+| radarr.ingress.tls.secretName | Name of the secret holding certificates for the secure ingress                                               | ""        | 
+| radarr.resources              | Limits and Requests for the container                                                                        | {}        |
 
 # Jackett
 
-| Config path | Meaning | Default | 
-| ------------ | ------------ | ------------ |
-| jackett.enabled | Flag if you want to enable jackett | true | 
-| jackett.container.port | The port in use by the container | 9117 | 
-| jackett.service.type | The kind of Service (ClusterIP/NodePort/LoadBalancer) | ClusterIP |
-| jackett.service.port | The port assigned to the service | 9117 |
-| jackett.service.nodePort | In case of service.type NodePort, the nodePort to use | "" |
-| jackett.service.extraLBService | If true, it creates an additional LoadBalancer service with '-lb' suffix (requires a cloud provider or metalLB) | false | 
-| jackett.ingress.enabled | If true, creates the ingress resource for the application | true |
-| jackett.ingress.annotations | Additional field for annotations, if needed | {} |
-| jackett.ingress.path | The path where the application is exposed | /jackett |
-| jackett.ingress.tls.enabled | If true, tls is enabled | false |
-| jackett.ingress.tls.secretName | Name of the secret holding certificates for the secure ingress | "" | 
-| jackett.resources | Limits and Requests for the container | {} |
+| Config path                    | Meaning                                                                                                         | Default   | 
+|--------------------------------|-----------------------------------------------------------------------------------------------------------------|-----------|
+| jackett.enabled                | Flag if you want to enable jackett                                                                              | true      | 
+| jackett.container.port         | The port in use by the container                                                                                | 9117      | 
+| jackett.service.type           | The kind of Service (ClusterIP/NodePort/LoadBalancer)                                                           | ClusterIP |
+| jackett.service.port           | The port assigned to the service                                                                                | 9117      |
+| jackett.service.nodePort       | In case of service.type NodePort, the nodePort to use                                                           | ""        |
+| jackett.service.extraLBService | If true, it creates an additional LoadBalancer service with '-lb' suffix (requires a cloud provider or metalLB) | false     | 
+| jackett.ingress.enabled        | If true, creates the ingress resource for the application                                                       | true      |
+| jackett.ingress.annotations    | Additional field for annotations, if needed                                                                     | {}        |
+| jackett.ingress.path           | The path where the application is exposed                                                                       | /jackett  |
+| jackett.ingress.tls.enabled    | If true, tls is enabled                                                                                         | false     |
+| jackett.ingress.tls.secretName | Name of the secret holding certificates for the secure ingress                                                  | ""        | 
+| jackett.resources              | Limits and Requests for the container                                                                           | {}        |
 
 # Transmission
 
-| Config path | Meaning | Default | 
-| ------------ | ------------ | ------------ |
-| transmission.enabled | Flag if you want to enable transmission | true | 
-| transmission.container.port.utp | The port in use by the container | 9091 | 
-| transmission.container.port.peer | The port in use by the container for peer connection | 51413 | 
-| transmission.service.utp.type | The kind of Service (ClusterIP/NodePort/LoadBalancer) for transmission itself | ClusterIP |
-| transmission.service.utp.port | The port assigned to the service for transmission itself | 9091 |
-| transmission.service.utp.nodePort | In case of service.type NodePort, the nodePort to use for transmission itself | "" |
-| transmission.service.utp.extraLBService | If true, creates an additional LoadBalancer service with '-lb' suffix (requires a cloud provider or metalLB) | false | 
-| transmission.service.peer.type | The kind of Service (ClusterIP/NodePort/LoadBalancer) for peer port | ClusterIP |
-| transmission.service.peer.port | The port assigned to the service for peer port | 51413 |
-| transmission.service.peer.nodePort | In case of service.type NodePort, the nodePort to use for peer port | "" |
-| transmission.service.peer.nodePortUDP | In case of service.type NodePort, the nodePort to use for peer port UDP service | "" |
-| transmission.service.peer.extraLBService | If true, creates an additional LoadBalancer service with '-lb' suffix (requires a cloud provider or metalLB) | false | 
-| transmission.ingress.enabled | If true, creates the ingress resource for the application | true |
-| transmission.ingress.annotations | Additional field for annotations, if needed | {} |
-| transmission.ingress.path | The path where the application is exposed | /transmission |
-| transmission.ingress.tls.enabled | If true, tls is enabled | false |
-| transmission.ingress.tls.secretName | Name of the secret holding certificates for the secure ingress | "" |
-| transmission.config.auth.enabled | Enables authentication for transmission | false |
-| transmission.config.auth.username | Username for transmission | "" |
-| transmission.config.auth.password | Password for transmission | "" | 
-| transmission.resources | Limits and Requests for the container | {} |
+| Config path                              | Meaning                                                                                                      | Default       | 
+|------------------------------------------|--------------------------------------------------------------------------------------------------------------|---------------|
+| transmission.enabled                     | Flag if you want to enable transmission                                                                      | true          | 
+| transmission.container.port.utp          | The port in use by the container                                                                             | 9091          | 
+| transmission.container.port.peer         | The port in use by the container for peer connection                                                         | 51413         | 
+| transmission.service.utp.type            | The kind of Service (ClusterIP/NodePort/LoadBalancer) for transmission itself                                | ClusterIP     |
+| transmission.service.utp.port            | The port assigned to the service for transmission itself                                                     | 9091          |
+| transmission.service.utp.nodePort        | In case of service.type NodePort, the nodePort to use for transmission itself                                | ""            |
+| transmission.service.utp.extraLBService  | If true, creates an additional LoadBalancer service with '-lb' suffix (requires a cloud provider or metalLB) | false         | 
+| transmission.service.peer.type           | The kind of Service (ClusterIP/NodePort/LoadBalancer) for peer port                                          | ClusterIP     |
+| transmission.service.peer.port           | The port assigned to the service for peer port                                                               | 51413         |
+| transmission.service.peer.nodePort       | In case of service.type NodePort, the nodePort to use for peer port                                          | ""            |
+| transmission.service.peer.nodePortUDP    | In case of service.type NodePort, the nodePort to use for peer port UDP service                              | ""            |
+| transmission.service.peer.extraLBService | If true, creates an additional LoadBalancer service with '-lb' suffix (requires a cloud provider or metalLB) | false         | 
+| transmission.ingress.enabled             | If true, creates the ingress resource for the application                                                    | true          |
+| transmission.ingress.annotations         | Additional field for annotations, if needed                                                                  | {}            |
+| transmission.ingress.path                | The path where the application is exposed                                                                    | /transmission |
+| transmission.ingress.tls.enabled         | If true, tls is enabled                                                                                      | false         |
+| transmission.ingress.tls.secretName      | Name of the secret holding certificates for the secure ingress                                               | ""            |
+| transmission.config.auth.enabled         | Enables authentication for transmission                                                                      | false         |
+| transmission.config.auth.username        | Username for transmission                                                                                    | ""            |
+| transmission.config.auth.password        | Password for transmission                                                                                    | ""            | 
+| transmission.resources                   | Limits and Requests for the container                                                                        | {}            |
 
 # Sabnzbd
 
-| Config path | Meaning | Default | 
-| ------------ | ------------ | ------------ |
-| sabnzbd.enabled | Flag if you want to enable sabnzbd | true | 
-| sabnzbd.container.port.http | The port in use by the container | 8080 | 
-| sabnzbd.container.port.https | The port in use by the container for peer connection | 9090 | 
-| sabnzbd.service.http.type | The kind of Service (ClusterIP/NodePort/LoadBalancer) for sabnzbd itself | ClusterIP |
-| sabnzbd.service.http.port | The port assigned to the service for sabnzbd itself | 9091 |
-| sabnzbd.service.http.nodePort | In case of service.type NodePort, the nodePort to use for sabnzbd itself | "" |
-| sabnzbd.service.http.extraLBService | If true, creates an additional LoadBalancer service with '-lb' suffix (requires a cloud provider or metalLB) | false | 
-| sabnzbd.service.https.type | The kind of Service (ClusterIP/NodePort/LoadBalancer) for https port | ClusterIP |
-| sabnzbd.service.https.port | The port assigned to the service for peer port | 51413 |
-| sabnzbd.service.https.nodePort | In case of service.type NodePort, the nodePort to use for https port | "" |
-| sabnzbd.service.https.extraLBService | If true, creates an additional LoadBalancer service with '-lb' suffix (requires a cloud provider or metalLB) | false | 
-| sabnzbd.ingress.enabled | If true, creates the ingress resource for the application | true |
-| sabnzbd.ingress.annotations | Additional field for annotations, if needed | {} |
-| sabnzbd.ingress.path | The path where the application is exposed | /sabnzbd |
-| sabnzbd.ingress.tls.enabled | If true, tls is enabled | false |
-| sabnzbd.ingress.tls.secretName | Name of the secret holding certificates for the secure ingress | "" | 
-| sabnzbd.resources | Limits and Requests for the container | {} |
+| Config path                          | Meaning                                                                                                      | Default   | 
+|--------------------------------------|--------------------------------------------------------------------------------------------------------------|-----------|
+| sabnzbd.enabled                      | Flag if you want to enable sabnzbd                                                                           | true      | 
+| sabnzbd.container.port.http          | The port in use by the container                                                                             | 8080      | 
+| sabnzbd.container.port.https         | The port in use by the container for peer connection                                                         | 9090      | 
+| sabnzbd.service.http.type            | The kind of Service (ClusterIP/NodePort/LoadBalancer) for sabnzbd itself                                     | ClusterIP |
+| sabnzbd.service.http.port            | The port assigned to the service for sabnzbd itself                                                          | 9091      |
+| sabnzbd.service.http.nodePort        | In case of service.type NodePort, the nodePort to use for sabnzbd itself                                     | ""        |
+| sabnzbd.service.http.extraLBService  | If true, creates an additional LoadBalancer service with '-lb' suffix (requires a cloud provider or metalLB) | false     | 
+| sabnzbd.service.https.type           | The kind of Service (ClusterIP/NodePort/LoadBalancer) for https port                                         | ClusterIP |
+| sabnzbd.service.https.port           | The port assigned to the service for peer port                                                               | 51413     |
+| sabnzbd.service.https.nodePort       | In case of service.type NodePort, the nodePort to use for https port                                         | ""        |
+| sabnzbd.service.https.extraLBService | If true, creates an additional LoadBalancer service with '-lb' suffix (requires a cloud provider or metalLB) | false     | 
+| sabnzbd.ingress.enabled              | If true, creates the ingress resource for the application                                                    | true      |
+| sabnzbd.ingress.annotations          | Additional field for annotations, if needed                                                                  | {}        |
+| sabnzbd.ingress.path                 | The path where the application is exposed                                                                    | /sabnzbd  |
+| sabnzbd.ingress.tls.enabled          | If true, tls is enabled                                                                                      | false     |
+| sabnzbd.ingress.tls.secretName       | Name of the secret holding certificates for the secure ingress                                               | ""        | 
+| sabnzbd.resources                    | Limits and Requests for the container                                                                        | {}        |
 
 ## About the project
 
-This project is intended as an exercise, and absolutely for fun. 
-This is not intended to promote piracy. 
+This project is intended as an exercise, and absolutely for fun.
+This is not intended to promote piracy.
 
 Also feel free to contribute and extend it!
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ With default settings, your applications will run in these paths:
     http://k8s-plex.k8s.test/
 
 ## Using a cluster-external NFS server
-This assumes that you have an already pre-configured NFS server set up on your network that is accessible from all nodes. If it is not accessible by all nodes, pods will not enter ready state when scheduled on nodes that do not have NFS access. 
+This assumes that you have a pre-configured NFS server set up on your network that is accessible from all nodes. If it is not accessible by all nodes, pods will not enter ready state when scheduled on nodes that do not have NFS access. 
 
 To add an NFS volume to each resource, create a `my-values.yaml` file and add the below. You should change the `server:` and `path:` values to match your NFS.
 
@@ -83,7 +83,7 @@ With this value saved in the top level directory of this repo, running the below
 helm install -f my-values.yaml k8s-mediaserver ./helm-charts/k8s-mediaserver/
 ```
 
-This is eqiuvalent to running `mount {SERVER-IP}:/mount/path/on/nfs/server ...` in each container, where `...` is different per resouce, as defined in the templatesdirectory (for each resource).
+This is eqiuvalent to running `mount {SERVER-IP}:/mount/path/on/nfs/server ...` in each container, where `...` is different per resource, as defined in the templates directory (for each resource).
 In addition to the above, you should also edit your subpaths so that they when they are appended to your `path:` specified in `values.yaml`, they map to the directories you intend.
 
 ## The mediaserver CR

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-## k8s-mediaserver-operator - Your all-in-one resource for your media needs!
+# k8s-mediaserver-operator
+
+Your all-in-one resource for your media needs!
 
 I am so happy to announce the first release of the **k8s-mediaserver-operator**, a project that mixes up some of the
 mainstream tools for your media needs.
@@ -22,6 +24,7 @@ trackers for torrents.
 [Sabnzbd](https://sabnzbd.org/ "Sabnzbd") - A free and easy binary newsreader.
 
 All container images used by the operator are from [linuxserver](https://github.com/linuxserver)
+
 - [linuxserver.io](https://www.linuxserver.io/ "linuxserver.io")
 
 Each of the components can be **enabled** or **disabled** if you already have something in place in your lab!
@@ -43,36 +46,41 @@ The operator and the CR are already configured with some defaults settings to ma
 
 All you need is:
 
-- A namespace where you want to put your CR and all the pods that will spawn
+- A namespace where you want to put your Custom Resource and all the pods that will spawn
 - Being able to provision an RWX PV where to store configurations, downloads, and all related stuff (suggested > 200GB).
-  Persistent Volume **or** StorageClasses for dynamically provisioned volumes are **REQUIRED**
+  Persistent Volume **or** StorageClasses for dynamically provisioned volumes are **REQUIRED** (See below for NFS)
 
-First install the CRD and the operator:
+1. First install the CRD and the operator:
 
 AMD/Intel:
-
-    kubectl apply -f k8s-mediaserver-operator.yml
+```shell
+kubectl apply -f k8s-mediaserver-operator.yml
+```
 
 ARM - Raspberry Pi:
+```shell
+kubectl apply -f k8s-mediaserver-operator-arm64.yml
+```
 
-    kubectl apply -f k8s-mediaserver-operator-arm64.yml
-
-Then you are good to go with the CR:
-
-    kubectl apply -f k8s-mediaserver.yml
+2. Install the custom resource:
+```shell
+kubectl apply -f k8s-mediaserver.yml
+```
 
 In seconds, you will be ready to use your applications!
 
 With default settings, your applications will run in these paths:
 
-    http://k8s-mediaserver.k8s.test/sonarr
-    http://k8s-mediaserver.k8s.test/radarr
-    http://k8s-mediaserver.k8s.test/transmission
-    http://k8s-mediaserver.k8s.test/jackett
+| Service      | Link                                           |
+|--------------|------------------------------------------------|
+| Sonarr       | http://k8s-mediaserver.k8s.test/sonarr         |
+| Radarr       | http://k8s-mediaserver.k8s.test/radarr         |
+| Transmission | http://k8s-mediaserver.k8s.test/transmission   |
+| Jackett      | http://k8s-mediaserver.k8s.test/jackett        |
+| PLEX         | http://k8s-plex.k8s.test/                      |
 
-    http://k8s-plex.k8s.test/
 
-## Using a cluster-external NFS server
+### Using a cluster-external NFS server
 
 This assumes that you have a pre-configured NFS server set up on your network that is accessible from all nodes. If it
 is not accessible by all nodes, pods will not enter ready state when scheduled on nodes that do not have NFS access.
@@ -93,7 +101,7 @@ general:
 With this value saved in the top level directory of this repo, running the below will add the resources to your cluster,
 under the helm release name `k8s-mediaserver`
 
-``` bash
+``` shell
 helm install -f my-values.yaml k8s-mediaserver ./helm-charts/k8s-mediaserver/
 ```
 
@@ -107,7 +115,7 @@ specified in `values.yaml`, they map to the directories you intend.
 The CR is quite simple to configure, and I tried to keep the number of parameters low to avoid confusion, but still
 letting some customization to fit the resource inside your cluster.
 
-# General config
+## General config
 
 | Config path                           | Meaning                                                                                                     | Default                                         | 
 |---------------------------------------|-------------------------------------------------------------------------------------------------------------|-------------------------------------------------|
@@ -130,7 +138,7 @@ letting some customization to fit the resource inside your cluster.
 | general.storage.volumes               | Supply custom volume to be mounted for all services                                                         | {}                                              |
 | general.ingress.ingressClassName      | Reference an IngressClass resource that contains additional Ingress configuration                           | ""                                              |
 
-# Plex
+### Plex
 
 | Config path                 | Meaning                                                                                                      | Default   | 
 |-----------------------------|--------------------------------------------------------------------------------------------------------------|-----------|
@@ -149,7 +157,7 @@ letting some customization to fit the resource inside your cluster.
 | plex.ingress.tls.secretName | Name of the secret holding certificates for the secure ingress                                               | ""        |
 | plex.resources              | Limits and Requests for the container                                                                        | {}        | 
 
-# Sonarr
+### Sonarr
 
 | Config path                   | Meaning                                                                                                      | Default   | 
 |-------------------------------|--------------------------------------------------------------------------------------------------------------|-----------|
@@ -166,7 +174,7 @@ letting some customization to fit the resource inside your cluster.
 | sonarr.ingress.tls.secretName | Name of the secret holding certificates for the secure ingress                                               | ""        | 
 | sonarr.resources              | Limits and Requests for the container                                                                        | {}        |
 
-# Radarr
+### Radarr
 
 | Config path                   | Meaning                                                                                                      | Default   | 
 |-------------------------------|--------------------------------------------------------------------------------------------------------------|-----------|
@@ -183,7 +191,7 @@ letting some customization to fit the resource inside your cluster.
 | radarr.ingress.tls.secretName | Name of the secret holding certificates for the secure ingress                                               | ""        | 
 | radarr.resources              | Limits and Requests for the container                                                                        | {}        |
 
-# Jackett
+### Jackett
 
 | Config path                    | Meaning                                                                                                         | Default   | 
 |--------------------------------|-----------------------------------------------------------------------------------------------------------------|-----------|
@@ -200,7 +208,7 @@ letting some customization to fit the resource inside your cluster.
 | jackett.ingress.tls.secretName | Name of the secret holding certificates for the secure ingress                                                  | ""        | 
 | jackett.resources              | Limits and Requests for the container                                                                           | {}        |
 
-# Transmission
+### Transmission
 
 | Config path                              | Meaning                                                                                                      | Default       | 
 |------------------------------------------|--------------------------------------------------------------------------------------------------------------|---------------|
@@ -226,7 +234,7 @@ letting some customization to fit the resource inside your cluster.
 | transmission.config.auth.password        | Password for transmission                                                                                    | ""            | 
 | transmission.resources                   | Limits and Requests for the container                                                                        | {}            |
 
-# Sabnzbd
+### Sabnzbd
 
 | Config path                          | Meaning                                                                                                      | Default   | 
 |--------------------------------------|--------------------------------------------------------------------------------------------------------------|-----------|
@@ -254,4 +262,3 @@ This project is intended as an exercise, and absolutely for fun.
 This is not intended to promote piracy.
 
 Also feel free to contribute and extend it!
-


### PR DESCRIPTION
Hi! 

Sorry about the number of changes, they are mostly just linter / formatter changes. The actual changes completed is the addition of a section explaining how to use a pre-existing and on-network NFS server. I struggled through doing this when moving from my containerized set up to K8s, as all of my media is stored on a NFS.

I did also slightly change the README.md contents, mostly in the form of change the header to a top level header, and others to lower level to comply to `mdl` default settings.

Happy to make / discuss any changes. Thanks for putting this together! :)