### PR TITLE
feat(docker) Updated base operator version to fix quay.io CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/operator-framework/helm-operator:v1.23.0
+FROM quay.io/operator-framework/helm-operator:v1.25.2
 
 ENV HOME=/opt/helm
 COPY watches.yaml ${HOME}/watches.yaml


### PR DESCRIPTION
According to quay.io, there's a few CVEs in the 1.23 operator that are fixed in 1.25.2

```
RHSA-2022:7089: libksba security update (Important)
RHSA-2022:7720: e2fsprogs security and bug fix update (Moderate)
RHSA-2022:7105: gnutls security update (Moderate)
RHSA-2022:7715: libxml2 security update (Moderate)
RHSA-2022:7108: sqlite security update (Moderate)
RHSA-2022:7106: zlib security update (Moderate)
```