### PR TITLE
Specify a custom volume for downloads folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ general:
       path: /mount/path/on/nfs/server/
 ```
 
+*Optional:* To use a specific NFS volume for downloads folder, you should add:
+
+``` yaml
+general:
+  storage:
+    customVolume: true
+  downloadsVolume:
+    nfs:
+      server: {SERVER-IP}
+      path: /mount/path/on/nfs/server/
+```
+
 With this value saved in the top level directory of this repo, running the below will add the resources to your cluster,
 under the helm release name `k8s-mediaserver`
 
@@ -126,6 +138,7 @@ letting some customization to fit the resource inside your cluster.
 | general.puid                          | The UID for the process                                                                                     | 1000                                            |
 | general.nodeSelector                  | Node Selector for all the pods                                                                              | {}                                              |
 | general.storage.customVolume          | Flag if you want to supply your own volume and not use a PVC                                                | false                                           |
+| general.storage.downloadsVolume       | Supply custom volume to be mounted for downloads folder                                                     | {}                                              |
 | general.storage.pvcName               | Name of the persistenVolumeClaim configured in deployments                                                  | mediaserver-pvc                                 |
 | general.storage.accessMode            | Access mode for mediaserver PVC in case of single nodes                                                     | ReadWriteMany                                   |
 | general.storage.pvcStorageClass       | Specifies a storageClass for the PVC                                                                        | ""                                              |

--- a/helm-charts/k8s-mediaserver/Chart.yaml
+++ b/helm-charts/k8s-mediaserver/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 1.16.0
 description: A Helm chart for Kubernetes mediaserver
 name: k8s-mediaserver
 type: application
-version: 0.7.0
+version: 0.7.1

--- a/helm-charts/k8s-mediaserver/templates/radarr-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/radarr-resources.yml
@@ -92,9 +92,15 @@ spec:
               mountPath: "/config"
               subPath: "{{ .Values.general.storage.subPaths.config }}/radarr"
           {{- end }}
+          {{- if (and ( .Values.general.storage.customVolume ) ( .Values.general.storage.downloadsVolume ) ) }}
+            - name: download-volume
+              mountPath: "/downloads"
+              subPath: "{{ .Values.general.storage.subPaths.downloads }}"
+          {{- else }}
             - name: mediaserver-volume
               mountPath: "/downloads"
               subPath: "{{ .Values.general.storage.subPaths.downloads }}"
+          {{- end }}
             - name: mediaserver-volume
               mountPath: "/movies"
               subPath: "{{ .Values.general.storage.subPaths.movies }}"
@@ -110,6 +116,10 @@ spec:
         {{- else }}
         - name: mediaserver-volume
           {{- toYaml .Values.general.storage.volumes | nindent 10 }}
+        {{- end }}
+        {{- if (and ( .Values.general.storage.customVolume ) ( .Values.general.storage.downloadsVolume ) ) }}
+        - name: download-volume
+          {{- toYaml .Values.general.storage.downloadsVolume | nindent 10 }}
         {{- end }}
         {{- if .Values.radarr.volume }}
         - name: {{ .Values.radarr.volume.name }}

--- a/helm-charts/k8s-mediaserver/templates/sonarr-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/sonarr-resources.yml
@@ -91,9 +91,15 @@ spec:
               mountPath: "/config"
               subPath: "{{ .Values.general.storage.subPaths.config }}/sonarr"
           {{- end }}
+          {{- if (and ( .Values.general.storage.customVolume ) ( .Values.general.storage.downloadsVolume ) ) }}
+            - name: download-volume
+              mountPath: "/downloads"
+              subPath: "{{ .Values.general.storage.subPaths.downloads }}"
+          {{- else }}
             - name: mediaserver-volume
               mountPath: "/downloads"
               subPath: "{{ .Values.general.storage.subPaths.downloads }}"
+          {{- end }}
             - name: mediaserver-volume
               mountPath: "/tv"
               subPath: "{{ .Values.general.storage.subPaths.tv }}"
@@ -109,6 +115,10 @@ spec:
         {{- else }}
         - name: mediaserver-volume
           {{- toYaml .Values.general.storage.volumes | nindent 10 }}
+        {{- end }}
+        {{- if (and ( .Values.general.storage.customVolume ) ( .Values.general.storage.downloadsVolume ) ) }}
+        - name: download-volume
+          {{- toYaml .Values.general.storage.downloadsVolume | nindent 10 }}
         {{- end }}
         {{- if .Values.sonarr.volume }}
         - name: {{ .Values.sonarr.volume.name }}

--- a/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
@@ -162,9 +162,15 @@ spec:
               mountPath: "/config"
               subPath: "{{ .Values.general.storage.subPaths.config }}/transmission"
           {{ end }}
+          {{ if (and ( .Values.general.storage.customVolume ) ( .Values.general.storage.downloadsVolume ) ) }}
+            - name: download-volume
+              mountPath: "/downloads"
+              subPath: "{{ .Values.general.storage.subPaths.downloads }}"
+          {{ else }}
             - name: mediaserver-volume
               mountPath: "/downloads"
               subPath: "{{ .Values.general.storage.subPaths.downloads }}"
+          {{ end }}
           {{- with .Values.transmission.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -177,6 +183,10 @@ spec:
         {{ else }}
         - name: mediaserver-volume
           {{- toYaml .Values.general.storage.volumes | nindent 10 }}
+        {{ end }}
+        {{ if (and ( .Values.general.storage.customVolume ) ( .Values.general.storage.downloadsVolume ) ) }}
+        - name: download-volume
+          {{- toYaml .Values.general.storage.downloadsVolume | nindent 10 }}
         {{ end }}
         {{ if .Values.transmission.volume }}
         - name: {{ .Values.transmission.volume.name }}

--- a/helm-charts/k8s-mediaserver/values.yaml
+++ b/helm-charts/k8s-mediaserver/values.yaml
@@ -28,6 +28,7 @@ general:
     volumes: {}
     #  hostPath:
     #    path: /mnt/share
+    downloadsVolume: {}
   ingress:
     ingressClassName: ""
 


### PR DESCRIPTION
I have introduced the possibility to specify an additional NFS volume for the downloads folder.

This can be useful when using for example the Synology download client and you store the downloaded file on a different volume and/or shared folder.

The best way would be to provide a list of volumes under `general.storage.volumes` but in order to avoid introducing a breaking changes on the current implementation, I have created a new key `general.storage.downloadsVolume`