### PR TITLE
Fix nodeSelector and its associated documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ letting some customization to fit the resource inside your cluster.
 | general.image_tag                     | The name of the image tag (arm32v7-latest, arm64v8-latest, development)                                     | latest                                          |
 | general.pgid                          | The GID for the process                                                                                     | 1000                                            |
 | general.puid                          | The UID for the process                                                                                     | 1000                                            |
-| general.nodeSelector                  | Node Selector for all the pods                                                                              | {}                                              |
+| general.nodeSelector                  | Default Node Selector for all the pods. Per-service nodeSelectors are merged against this.                  | {}                                              |
 | general.storage.customVolume          | Flag if you want to supply your own volume and not use a PVC                                                | false                                           |
 | general.storage.pvcName               | Name of the persistenVolumeClaim configured in deployments                                                  | mediaserver-pvc                                 |
 | general.storage.accessMode            | Access mode for mediaserver PVC in case of single nodes                                                     | ReadWriteMany                                   |
@@ -131,6 +131,7 @@ letting some customization to fit the resource inside your cluster.
 | plex.enabled                              | Flag if you want to enable plex                                                                               | true      | 
 | plex.claim                                | **IMPORTANT** Token from your account, needed to claim the server                                             | CHANGEME  |
 | plex.replicaCount                         | Number of replicas serving plex                                                                               | 1         | 
+| plex.container.nodeSelector               | Node Selector for the Plex pods                                                                               | {}        |
 | plex.container.port                       | The port in use by the container                                                                              | 32400     | 
 | plex.container.image                      | The image used by the container                                                                               | docker.io/linuxserver/plex |
 | plex.container.tag                        | The tag used by the container                                                                                 | null      | 
@@ -152,6 +153,7 @@ letting some customization to fit the resource inside your cluster.
 | Config path                                 | Meaning                                                                                                        | Default   | 
 |---------------------------------------------|----------------------------------------------------------------------------------------------------------------|-----------|
 | sonarr.enabled                              | Flag if you want to enable sonarr                                                                              | true      | 
+| sonarr.container.nodeSelector               | Node Selector for the Sonarr pods                                                                              | {}        |
 | sonarr.container.port                       | The port in use by the container                                                                               | 8989      | 
 | sonarr.container.image                      | The image used by the container                                                                                | docker.io/linuxserver/sonarr |
 | sonarr.container.tag                        | The tag used by the container                                                                                  | null      | 
@@ -173,6 +175,7 @@ letting some customization to fit the resource inside your cluster.
 | Config path                                 | Meaning                                                                                                        | Default   | 
 |---------------------------------------------|----------------------------------------------------------------------------------------------------------------|-----------|
 | radarr.enabled                              | Flag if you want to enable radarr                                                                              | true      | 
+| radarr.container.nodeSelector               | Node Selector for the Radarr pods                                                                              | {}        |
 | radarr.container.port                       | The port in use by the container                                                                               | 7878      | 
 | radarr.container.image                      | The image used by the container                                                                                | docker.io/linuxserver/radarr |
 | radarr.container.tag                        | The tag used by the container                                                                                  | null      |
@@ -194,6 +197,7 @@ letting some customization to fit the resource inside your cluster.
 | Config path                                 | Meaning                                                                                                         | Default   | 
 |---------------------------------------------|-----------------------------------------------------------------------------------------------------------------|-----------|
 | jackett.enabled                             | Flag if you want to enable jackett                                                                              | true      | 
+| jackett.container.nodeSelector              | Node Selector for the Jackett pods                                                                              | {}        |
 | jackett.container.port                      | The port in use by the container                                                                                | 9117      | 
 | jackett.container.image                     | The image used by the container                                                                                 | docker.io/linuxserver/jackett |
 | jackett.container.tag                       | The tag used by the container                                                                                   | null      |
@@ -215,6 +219,7 @@ letting some customization to fit the resource inside your cluster.
 | Config path                                   | Meaning                                                                                                         | Default   | 
 |-----------------------------------------------|-----------------------------------------------------------------------------------------------------------------|-----------|
 | prowlarr.enabled                              | Flag if you want to enable prowlarr                                                                             | true      | 
+| prowlarr.container.nodeSelector               | Node Selector for the Prowlarr pods                                                                             | {}        |
 | prowlarr.container.port                       | The port in use by the container                                                                                | 9117      | 
 | prowlarr.container.image                      | The image used by the container                                                                                 | docker.io/linuxserver/prowlarr |
 | prowlarr.container.tag                        | The tag used by the container                                                                                   | develop   |
@@ -236,6 +241,7 @@ letting some customization to fit the resource inside your cluster.
 | Config path                                       | Meaning                                                                                                        | Default       | 
 |---------------------------------------------------|----------------------------------------------------------------------------------------------------------------|---------------|
 | transmission.enabled                              | Flag if you want to enable transmission                                                                        | true          | 
+| transmission.container.nodeSelector               | Node Selector for the Transmission pods                                                                        | {}        |
 | transmission.container.port.utp                   | The port in use by the container                                                                               | 9091          | 
 | transmission.container.port.peer                  | The port in use by the container for peer connection                                                           | 51413         | 
 | transmission.container.image                      | The image used by the container                                                                                | docker.io/linuxserver/transmission |
@@ -266,6 +272,7 @@ letting some customization to fit the resource inside your cluster.
 | Config path                                 | Meaning                                                                                                        | Default   | 
 |---------------------------------------------|----------------------------------------------------------------------------------------------------------------|-----------|
 | sabnzbd.enabled                             | Flag if you want to enable sabnzbd                                                                             | true      | 
+| sabnzbd.container.nodeSelector              | Node Selector for the Sabnzbd pods                                                                             | {}        |
 | sabnzbd.container.port.http                 | The port in use by the container                                                                               | 8080      | 
 | sabnzbd.container.port.https                | The port in use by the container for peer connection                                                           | 9090      | 
 | sabnzbd.container.image                     | The image used by the container                                                                                | docker.io/linuxserver/sabnzbd |

--- a/helm-charts/k8s-mediaserver/templates/jackett-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/jackett-resources.yml
@@ -111,7 +111,7 @@ spec:
           configMap:
             defaultMode: 493
             name: init-jackett-cm
-      {{- with .Values.general.nodeSelector }}
+      {{- with merge .Values.jackett.container.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm-charts/k8s-mediaserver/templates/plex-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/plex-resources.yml
@@ -77,7 +77,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- with .Values.general.nodeSelector }}
+      {{- with merge .Values.plex.container.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm-charts/k8s-mediaserver/templates/prowlarr-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/prowlarr-resources.yml
@@ -111,7 +111,7 @@ spec:
           configMap:
             defaultMode: 493
             name: init-prowlarr-cm
-      {{- with .Values.general.nodeSelector }}
+      {{- with merge .Values.prowlarr.container.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm-charts/k8s-mediaserver/templates/radarr-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/radarr-resources.yml
@@ -120,7 +120,7 @@ spec:
           configMap:
             defaultMode: 493
             name: init-radarr-cm
-      {{- with .Values.general.nodeSelector }}
+      {{- with merge .Values.radarr.container.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm-charts/k8s-mediaserver/templates/sabnzbd-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/sabnzbd-resources.yml
@@ -420,7 +420,7 @@ spec:
           configMap:
             defaultMode: 493
             name: init-sabnzbd-cm
-      {{- with .Values.general.nodeSelector }}
+      {{- with merge .Values.sabnzbd.container.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm-charts/k8s-mediaserver/templates/sonarr-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/sonarr-resources.yml
@@ -119,7 +119,7 @@ spec:
           configMap:
             defaultMode: 493
             name: init-sonarr-cm
-      {{- with .Values.general.nodeSelector }}
+      {{- with merge .Values.sonarr.container.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
@@ -187,7 +187,7 @@ spec:
           configMap:
             defaultMode: 493
             name: init-transmission-cm
-      {{- with .Values.general.nodeSelector }}
+      {{- with merge .Values.transmission.container.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm-charts/k8s-mediaserver/values.yaml
+++ b/helm-charts/k8s-mediaserver/values.yaml
@@ -30,6 +30,7 @@ general:
     #    path: /mnt/share
   ingress:
     ingressClassName: ""
+  nodeSelector: {}
 
 sonarr:
   enabled: true


### PR DESCRIPTION
Previously, the templates and README.md referenced a general.nodeSelector field that didn't exist in
helm-charts/k8s-mediaserver/values.yaml or k8s-mediaserver.yml files. Conversely, those yaml/yml files allow for per-pod node selection, which allows for more flexibility. We've gotta resolve this inconsistency somehow, so let's maintain the general approach as documented but merge in service-specific selectors for improved flexibility.