### PR TITLE
fix(charts): Added extraLBAnnotations and fixed mismatched ports

### DIFF
--- a/helm-charts/k8s-mediaserver/templates/jackett-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/jackett-resources.yml
@@ -142,8 +142,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: jackett-lb
+  {{- with .Values.jackett.service.extraLBAnnotations }}
   annotations:
-    {{- include .Values.jackett.service.extraLBService.annotations . | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "k8s-mediaserver.labels" . | nindent 4 }}
 spec:

--- a/helm-charts/k8s-mediaserver/templates/plex-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/plex-resources.yml
@@ -108,8 +108,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: plex-lb
+  {{- with .Values.plex.service.extraLBAnnotations }}
   annotations:
-    {{- include .Values.plex.service.extraLBService.annotations . | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "k8s-mediaserver.labels" . | nindent 4 }}
 spec:

--- a/helm-charts/k8s-mediaserver/templates/prowlarr-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/prowlarr-resources.yml
@@ -142,8 +142,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prowlarr-lb
+  {{- with .Values.prowlarr.service.extraLBAnnotations }}
   annotations:
-    {{- include .Values.prowlarr.service.extraLBService.annotations . | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "k8s-mediaserver.labels" . | nindent 4 }}
 spec:

--- a/helm-charts/k8s-mediaserver/templates/radarr-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/radarr-resources.yml
@@ -151,8 +151,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: radarr-lb
+  {{- with .Values.radarr.service.extraLBAnnotations }}
   annotations:
-    {{- include .Values.radarr.service.extraLBService.annotations . | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "k8s-mediaserver.labels" . | nindent 4 }}
 spec:

--- a/helm-charts/k8s-mediaserver/templates/sabnzbd-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/sabnzbd-resources.yml
@@ -455,7 +455,7 @@ spec:
   type: {{ .Values.sabnzbd.service.https.type }}
   ports:
     - port: {{ .Values.sabnzbd.service.https.port }}
-      targetPort: {{ .Values.sabnzbd.container.port.http }}
+      targetPort: {{ .Values.sabnzbd.container.port.https }}
       protocol: TCP
       name: sabnzbd-https
 {{ if eq .Values.sabnzbd.service.http.type "NodePort" }}
@@ -469,8 +469,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: sabnzbd-lb
+  {{- with .Values.sabnzbd.service.http.extraLBAnnotations }}
   annotations:
-    {{- include .Values.sabnzbd.service.extraLBService.annotations . | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "k8s-mediaserver.labels" . | nindent 4 }}
 spec:
@@ -489,6 +491,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: sabnzbd-lb-https
+  {{- with .Values.sabnzbd.service.https.extraLBAnnotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "k8s-mediaserver.labels" . | nindent 4 }}
 spec:

--- a/helm-charts/k8s-mediaserver/templates/sonarr-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/sonarr-resources.yml
@@ -149,8 +149,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: sonarr-lb
+  {{- with .Values.sonarr.service.extraLBAnnotations }}
   annotations:
-    {{- include .Values.sonarr.service.extraLBService.annotations . | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "k8s-mediaserver.labels" . | nindent 4 }}
 spec:

--- a/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
@@ -255,15 +255,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: transmission-lb
+  {{- with .Values.transmission.service.utp.extraLBAnnotations }}
   annotations:
-    {{- include .Values.transmission.service.extraLBService.annotations . | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "k8s-mediaserver.labels" . | nindent 4 }}
 spec:
   type: LoadBalancer
   ports:
-    - port: {{ .Values.transmission.service.port }}
-      targetPort: {{ .Values.transmission.container.port }}
+    - port: {{ .Values.transmission.service.utp.port }}
+      targetPort: {{ .Values.transmission.container.port.utp }}
       protocol: TCP
       name: trans-port
   selector:
@@ -275,6 +277,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: transmission-lb-peer-tcp
+  {{- with .Values.transmission.service.peer.extraLBAnnotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "k8s-mediaserver.labels" . | nindent 4 }}
 spec:
@@ -291,6 +297,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: transmission-lb-peer-udp
+  {{- with .Values.transmission.service.peer.extraLBAnnotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "k8s-mediaserver.labels" . | nindent 4 }}
 spec:

--- a/helm-charts/k8s-mediaserver/values.yaml
+++ b/helm-charts/k8s-mediaserver/values.yaml
@@ -16,7 +16,6 @@ general:
     pvcName: mediaserver-pvc
     size: 5Gi
     pvcStorageClass: ""
-    accessMode: ""
     # the path starting from the top level of the pv you're passing. If your share is server.local/share/, then tv is server.local/share/media/tv
     subPaths:
       tv: media/tv
@@ -43,6 +42,7 @@ sonarr:
     port: 8989
     nodePort:
     extraLBService: false
+    extraLBAnnotations: {}
     # Defines an additional LB service, requires cloud provider service or MetalLB
   ingress:
     enabled: true
@@ -73,8 +73,9 @@ radarr:
     type: ClusterIP
     port: 7878
     nodePort:
-    extraLBService: false
     # Defines an additional LB service, requires cloud provider service or MetalLB
+    extraLBService: false
+    extraLBAnnotations: {}
   ingress:
     enabled: true
     annotations: {}
@@ -103,6 +104,7 @@ jackett:
     port: 9117
     nodePort:
     extraLBService: false
+    extraLBAnnotations: {}
     # Defines an additional LB service, requires cloud provider service or MetalLB
   ingress:
     enabled: true
@@ -133,16 +135,20 @@ transmission:
     utp:
       type: ClusterIP
       port: 9091
+      # if type is NodePort, nodePort must be set
       nodePort:
       # Defines an additional LB service, requires cloud provider service or MetalLB
       extraLBService: false
+      extraLBAnnotations: {}
     peer:
       type: ClusterIP
       port: 51413
+      # if type is NodePort, nodePort and nodePortUDP must be set
       nodePort:
       nodePortUDP:
       # Defines an additional LB service, requires cloud provider service or MetalLB
       extraLBService: false
+      extraLBAnnotations: {}
   ingress:
     enabled: true
     annotations: {}
@@ -180,12 +186,14 @@ sabnzbd:
       nodePort:
       # Defines an additional LB service, requires cloud provider service or MetalLB
       extraLBService: false
+      extraLBAnnotations: {}
     https:
       type: ClusterIP
       port: 9090
       nodePort:
       # Defines an additional LB service, requires cloud provider service or MetalLB
       extraLBService: false
+      extraLBAnnotations: {}
   ingress:
     enabled: true
     annotations: {}
@@ -205,7 +213,7 @@ sabnzbd:
 
 prowlarr:
   enabled: true
-  container: 
+  container:
     image: docker.io/linuxserver/prowlarr
     tag: develop
     nodeSelector: {}
@@ -213,8 +221,9 @@ prowlarr:
   service:
     type: ClusterIP
     port: 9696
-    nodePort: 
+    nodePort:
     extraLBService: false
+    extraLBAnnotations: {}
   ingress:
     enabled: true
     annotations: {}
@@ -246,6 +255,7 @@ plex:
     nodePort:
     # Defines an additional LB service, requires cloud provider service or MetalLB
     extraLBService: false
+    extraLBAnnotations: {}
   ingress:
     enabled: true
     annotations: {}


### PR DESCRIPTION
Addresses some of the issues with the extra loadbalancer service raised in #71 

- Annotations are now set in their own field and extraLBService can now be a simple bool.
- sabnzbd had both http and https ports pointing to only the http port

Manually tested working with on/off load balancers and annotations. The ports also now work.

**Possible breakage**
.Values.transmission.service.port was previously unset in the chart values, but determined users might have set them to overcome error messages that the chart or operator would have raised. Those configs would now be ignored to reflect what was really in the values.yaml file (and previously in the transmission-resources.yaml file).

We can also go the other way around and unset utp and set default values for .Values.transmission.service

