### PR TITLE
feat(charts): Add Transmission VPN

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,34 +280,35 @@ letting some customization to fit the resource inside your cluster.
 
 ### Transmission
 
-| Config path                                     | Meaning                                                                                                       | Default                            |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
-| transmission.enabled                            | Flag if you want to enable Transmission                                                                       | true                               |
-| transmission.container.port.utp                 | The port in use by the container                                                                              | 9091                               |
-| transmission.container.nodeSelector             | Node Selector for the Transmission pods                                                                       | {}                                 |
-| transmission.container.port.peer                | The port in use by the container for peer connection                                                          | 51413                              |
-| transmission.container.image                    | The image used by the container                                                                               | docker.io/linuxserver/transmission |
-| transmission.container.tag                      | The tag used by the container                                                                                 | null                               |
-| transmission.service.utp.type                   | The kind of Service (ClusterIP/NodePort/LoadBalancer) for Transmission itself                                 | ClusterIP                          |
-| transmission.service.utp.port                   | The port assigned to the service for Transmission itself                                                      | 9091                               |
-| transmission.service.utp.nodePort               | In case of service.type NodePort, the nodePort to use for Transmission itself                                 | ""                                 |
-| transmission.service.utp.extraLBService         | If true, creates an additional LoadBalancer service with '-lb' suffix (requires a cloud provider or metalLB)  | false                              |
-| transmission.service.peer.type                  | The kind of Service (ClusterIP/NodePort/LoadBalancer) for peer port                                           | ClusterIP                          |
-| transmission.service.peer.port                  | The port assigned to the service for peer port                                                                | 51413                              |
-| transmission.service.peer.nodePort              | In case of service.type NodePort, the nodePort to use for peer port                                           | ""                                 |
-| transmission.service.peer.nodePortUDP           | In case of service.type NodePort, the nodePort to use for peer port UDP service                               | ""                                 |
-| transmission.service.peer.extraLBService        | If true, creates an additional LoadBalancer service with '-lb' suffix (requires a cloud provider or metalLB)  | false                              |
-| transmission.service.extraLBService.annotations | Instead of using extraLBService as a bool, you can use it as a map to define annotations on the loadbalancer  | null                               |
-| transmission.ingress.enabled                    | If true, creates the ingress resource for the application                                                     | true                               |
-| transmission.ingress.annotations                | Additional field for annotations, if needed                                                                   | {}                                 |
-| transmission.ingress.path                       | The path where the application is exposed                                                                     | /transmission                      |
-| transmission.ingress.tls.enabled                | If true, tls is enabled                                                                                       | false                              |
-| transmission.ingress.tls.secretName             | Name of the secret holding certificates for the secure ingress                                                | ""                                 |
-| transmission.config.auth.enabled                | Enables authentication for Transmission                                                                       | false                              |
-| transmission.config.auth.username               | Username for Transmission                                                                                     | ""                                 |
-| transmission.config.auth.password               | Password for Transmission                                                                                     | ""                                 |
-| transmission.resources                          | Limits and Requests for the container                                                                         | {}                                 |
-| transmission.volume                             | If set, Plex will create a PVC for it's config volume, else it will be put on general.storage.subPaths.config | {}                                 |
+| Config path                                     | Meaning                                                                                                                                                          | Default                            |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| transmission.enabled                            | Flag if you want to enable Transmission                                                                                                                          | true                               |
+| transmission.container.port.utp                 | The port in use by the container                                                                                                                                 | 9091                               |
+| transmission.container.nodeSelector             | Node Selector for the Transmission pods                                                                                                                          | {}                                 |
+| transmission.container.port.peer                | The port in use by the container for peer connection                                                                                                             | 51413                              |
+| transmission.container.image                    | The image used by the container                                                                                                                                  | docker.io/linuxserver/transmission |
+| transmission.container.tag                      | The tag used by the container                                                                                                                                    | null                               |
+| transmission.service.utp.type                   | The kind of Service (ClusterIP/NodePort/LoadBalancer) for Transmission itself                                                                                    | ClusterIP                          |
+| transmission.service.utp.port                   | The port assigned to the service for Transmission itself                                                                                                         | 9091                               |
+| transmission.service.utp.nodePort               | In case of service.type NodePort, the nodePort to use for Transmission itself                                                                                    | ""                                 |
+| transmission.service.utp.extraLBService         | If true, creates an additional LoadBalancer service with '-lb' suffix (requires a cloud provider or metalLB)                                                     | false                              |
+| transmission.service.peer.type                  | The kind of Service (ClusterIP/NodePort/LoadBalancer) for peer port                                                                                              | ClusterIP                          |
+| transmission.service.peer.port                  | The port assigned to the service for peer port                                                                                                                   | 51413                              |
+| transmission.service.peer.nodePort              | In case of service.type NodePort, the nodePort to use for peer port                                                                                              | ""                                 |
+| transmission.service.peer.nodePortUDP           | In case of service.type NodePort, the nodePort to use for peer port UDP service                                                                                  | ""                                 |
+| transmission.service.peer.extraLBService        | If true, creates an additional LoadBalancer service with '-lb' suffix (requires a cloud provider or metalLB)                                                     | false                              |
+| transmission.service.extraLBService.annotations | Instead of using extraLBService as a bool, you can use it as a map to define annotations on the loadbalancer                                                     | null                               |
+| transmission.ingress.enabled                    | If true, creates the ingress resource for the application                                                                                                        | true                               |
+| transmission.ingress.annotations                | Additional field for annotations, if needed                                                                                                                      | {}                                 |
+| transmission.ingress.path                       | The path where the application is exposed                                                                                                                        | /transmission                      |
+| transmission.ingress.tls.enabled                | If true, tls is enabled                                                                                                                                          | false                              |
+| transmission.ingress.tls.secretName             | Name of the secret holding certificates for the secure ingress                                                                                                   | ""                                 |
+| transmission.config.auth.enabled                | Enables authentication for Transmission                                                                                                                          | false                              |
+| transmission.config.auth.username               | Username for Transmission                                                                                                                                        | ""                                 |
+| transmission.config.auth.password               | Password for Transmission                                                                                                                                        | ""                                 |
+| transmission.resources                          | Limits and Requests for the container                                                                                                                            | {}                                 |
+| transmission.volume                             | If set, Plex will create a PVC for it's config volume, else it will be put on general.storage.subPaths.config                                                    | {}                                 |
+| transmission.vpn.enabled                        | If set, a [gluetun](https://github.com/qdm12/gluetun-wiki) sidecar will be provisioned to route the traffic through a VPN. This requires a 3rd party VPN account | {}                                 |
 
 ### Sabnzbd
 
@@ -376,9 +377,34 @@ plex:
         service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags:
 ```
 
+### Setting up the VPN
+
+If you have enabled the VPN for transmission you will need to fullfill the rest of parameters related to it, currently only [Mullvad](https://mullvad.net) VPN is supported.
+
+The following shows an example of the current settings for mullvard.
+
+```yaml
+vpn:
+  enabled: true
+  provider: mullvad
+  type: openvpn
+  user: "XXXXXX"
+  city: zurich
+```
+
 ## About the project
 
 This project is intended as an exercise, and absolutely for fun.
 This is not intended to promote piracy.
 
 Also feel free to contribute and extend it!
+
+### Uninstalling the helm chart
+
+To fully remove all the resources created you should uninstall the helm deployment.
+
+```bash
+  helm uninstall k8s-mediaserver
+```
+
+This will not delete the Custom Resources like the operator.

--- a/helm-charts/k8s-mediaserver/Chart.yaml
+++ b/helm-charts/k8s-mediaserver/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 0.10.0
+appVersion: 0.10.1
 description: A Helm chart for Kubernetes mediaserver
 name: k8s-mediaserver
 type: application
-version: 0.10.0
+version: 0.10.1

--- a/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
@@ -173,6 +173,28 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- if .Values.transmission.vpn.enabled }}
+        - name: gluetun
+          image: ghcr.io/qdm12/gluetun # Optionally you can use the "qmcgaw/gluetun" image as well as specify what version of Gluetun you desire
+          imagePullPolicy: Always
+          securityContext:
+            capabilities:
+              add: ["NET_ADMIN"]
+          env:
+          {{- if eq .Values.transmission.vpn.provider  `mullvad` }}
+            # https://github.com/qdm12/gluetun-wiki/blob/main/setup/providers/mullvad.md
+            - name: TZ
+              value: "Europe/London"
+            - name: VPN_SERVICE_PROVIDER
+              value: "{{ .Values.transmission.vpn.provider }}"
+            - name: VPN_TYPE
+              value: "{{ .Values.transmission.vpn.type }}"
+            - name: OPENVPN_USER
+              value: {{ .Values.transmission.vpn.user | quote }}
+            - name: SERVER_CITIES
+              value: {{ .Values.transmission.vpn.city }}
+          {{ end }}
+        {{- end }}
       volumes:
         {{ if not .Values.general.storage.customVolume }}
         - name: mediaserver-volume

--- a/helm-charts/k8s-mediaserver/values.yaml
+++ b/helm-charts/k8s-mediaserver/values.yaml
@@ -166,6 +166,8 @@ transmission:
       password: ""
   resources: {}
   volume: {}
+  vpn:
+    enabled: false
   #  name: pvc-transmission-config
   #  storageClassName: longhorn
   #  annotations: {}

--- a/k8s-mediaserver.yml
+++ b/k8s-mediaserver.yml
@@ -8,6 +8,7 @@ spec:
   general:
     ingress_host: k8s-mediaserver.k8s.test
     plex_ingress_host: k8s-plex.k8s.test
+    jellyfin_ingress_host: k8s-jellyfin.k8s.test
     image_tag: latest
     podDistribution: cluster # can be "spread" or "cluster"
     #UID to run the process with
@@ -170,6 +171,8 @@ spec:
         password: ""
     resources: {}
     volume: {}
+    vpn:
+      enabled: false
     #  name: pvc-transmission-config
     #  storageClassName: longhorn
     #  annotations: {}


### PR DESCRIPTION
This adds a sidecar container that will route the traffic from transmission out through a VPN. The side container is [Gluetun](https://github.com/qdm12/gluetun-wiki) and supports most of the VPN's, and the setup should be easy.

Right now only Mullvad has been implemented, but extending this should be relatively easy by anyone.