### PR TITLE
Fixing plex http probe

### DIFF
--- a/helm-charts/k8s-mediaserver/templates/plex-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/plex-resources.yml
@@ -54,7 +54,7 @@ spec:
           readinessProbe:
             httpGet:
               port: {{ .Values.plex.container.port }}
-              path: "/"
+              path: "/web/index.html"
             initialDelaySeconds: 20
             periodSeconds: 15
             timeoutSeconds: 20


### PR DESCRIPTION
Fixing the HTTP probe. I've tested it on my cluster and it works fine.
The current HTTP probe doesn't work and causes the incorrect pod start, thus the incorrect ingress readiness