### PR TITLE
VPN with Gluetun

### DIFF
--- a/helm-charts/k8s-mediaserver/templates/_vpn-gluetun.tpl
+++ b/helm-charts/k8s-mediaserver/templates/_vpn-gluetun.tpl
@@ -1,0 +1,42 @@
+{{ define "vpn-gluetun.container" }}
+name: gluetun
+image: qmcgaw/gluetun:latest
+imagePullPolicy: Always
+env:
+  - name: TZ
+    value: America/Chicago
+  - name: VPN_SERVICE_PROVIDER
+    value: {{ .Values.general.vpn.provider }}
+  - name: VPN_TYPE
+    value: {{ .Values.general.vpn.type }}
+  - name: SERVER_REGIONS
+    value: {{ .Values.general.vpn.region }}
+  - name: OPENVPN_USER
+    value: {{ .Values.general.vpn.user }}
+  - name: OPENVPN_PASSWORD
+    value: {{ .Values.general.vpn.password }}
+ports:
+  - containerPort: 9091
+    protocol: TCP
+resources: {}
+securityContext:
+  capabilities:
+    add:
+      - NET_ADMIN
+terminationMessagePath: /dev/termination-log
+terminationMessagePolicy: File
+{{- end }}
+
+{{ define "vpn-gluetun.dnsConfig" }}
+dnsConfig:
+  nameservers:
+    - 10.255.255.1
+  options:
+    - name: ndots
+      value: '5'
+  searches:
+    - media.svc.cluster.local
+    - svc.cluster.local
+    - cluster.local
+dnsPolicy: None
+{{- end }}

--- a/helm-charts/k8s-mediaserver/templates/sabnzbd-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/sabnzbd-resources.yml
@@ -406,6 +406,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- if .Values.sabnzbd.vpn.enabled }}
+        - {{- include "vpn-gluetun.container" . | nindent 10 }}
+        {{- include "vpn-gluetun.dnsConfig" . | nindent 6 }}
+        {{- end }}
       volumes:
         {{- if not .Values.general.storage.customVolume }}
         - name: mediaserver-volume

--- a/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
@@ -173,7 +173,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-        {{- if .Values.sabnzbd.vpn.enabled }}
+        {{- if .Values.transmission.vpn.enabled }}
         - {{- include "vpn-gluetun.container" . | nindent 10 }}
         {{- include "vpn-gluetun.dnsConfig" . | nindent 6 }}
         {{- end }}

--- a/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/transmission-resources.yml
@@ -173,6 +173,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- if .Values.sabnzbd.vpn.enabled }}
+        - {{- include "vpn-gluetun.container" . | nindent 10 }}
+        {{- include "vpn-gluetun.dnsConfig" . | nindent 6 }}
+        {{- end }}
       volumes:
         {{ if not .Values.general.storage.customVolume }}
         - name: mediaserver-volume


### PR DESCRIPTION
In this fork, I've stubbed in Gluetun VPN. In this configuration, I use the OpenVPN protocol with Windscribe as a provider. Also, I only apply it to Transmission and SABnzbd. However, the Helm-templated pattern may be useful for others.

⚡ 