### PR TITLE
Add qBittorrent Helm Resources and Update Storage/Values

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,45 @@ letting some customization to fit the resource inside your cluster.
 | sabnzbd.resources                          | Limits and Requests for the container                                                                         | {}                            |
 | sabnzbd.volume                             | If set, Plex will create a PVC for it's config volume, else it will be put on general.storage.subPaths.config | {}                            |
 
+### qBittorrent
+
+| Config path                                 | Meaning                                                                                                           | Default                        |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| qbittorrent.enabled                        | Flag if you want to enable qBittorrent                                                                            | true                           |
+| qbittorrent.container.image                 | The image used by the container                                                                                   | ghcr.io/linuxserver/qbittorrent|
+| qbittorrent.container.tag                   | The tag used by the container                                                                                     | version-5.0.3-r0               |
+| qbittorrent.container.nodeSelector          | Node Selector for the qBittorrent pods                                                                            | {}                             |
+| qbittorrent.container.port.http             | The port in use by the container for the Web UI                                                                   | 8080                           |
+| qbittorrent.container.port.peer             | The port in use by the container for peer connections (TCP/UDP)                                                   | 6881                           |
+| qbittorrent.service.http.type               | The kind of Service (ClusterIP/NodePort/LoadBalancer) for the Web UI                                              | ClusterIP                      |
+| qbittorrent.service.http.port               | The port assigned to the service for the Web UI                                                                   | 8080                           |
+| qbittorrent.service.http.nodePort           | In case of service.type NodePort, the nodePort to use for the Web UI                                              | ""                             |
+| qbittorrent.service.http.extraLBService     | If true, creates an additional LoadBalancer service with '-lb' suffix (requires a cloud provider or MetalLB)      | false                          |
+| qbittorrent.service.http.extraLBAnnotations | Annotations for the extra load balancer service                                                                   | {}                             |
+| qbittorrent.service.peer.type               | The kind of Service (ClusterIP/NodePort/LoadBalancer) for peer connections                                        | ClusterIP                      |
+| qbittorrent.service.peer.port               | The port assigned to the service for peer connections (TCP/UDP)                                                   | 6881                           |
+| qbittorrent.service.peer.nodePort           | In case of service.type NodePort, the nodePort to use for peer TCP                                                | ""                             |
+| qbittorrent.service.peer.nodePortUDP        | In case of service.type NodePort, the nodePort to use for peer UDP                                                | ""                             |
+| qbittorrent.service.peer.extraLBService     | If true, creates an additional LoadBalancer service for peer connections                                          | false                          |
+| qbittorrent.service.peer.extraLBAnnotations | Annotations for the extra peer load balancer service                                                              | {}                             |
+| qbittorrent.ingress.enabled                 | If true, creates the ingress resource for the application                                                         | true                           |
+| qbittorrent.ingress.annotations             | Additional field for annotations, if needed                                                                       | {}                             |
+| qbittorrent.ingress.tls.enabled             | If true, tls is enabled                                                                                           | false                          |
+| qbittorrent.ingress.tls.secretName          | Name of the secret holding certificates for the secure ingress                                                    | ""                             |
+| qbittorrent.config.timezone                 | Timezone for the container                                                                                        | UTC                            |
+| qbittorrent.config.auth.enabled             | Enables authentication for qBittorrent Web UI                                                                     | false                          |
+| qbittorrent.config.auth.username            | Username for qBittorrent Web UI (if auth enabled)                                                                 | admin                          |
+| qbittorrent.config.auth.passwordHash        | PBKDF2 hash for the Web UI password (if auth enabled)                                                            | ""                             |
+| qbittorrent.resources                       | Limits and Requests for the container                                                                             | {}                             |
+| qbittorrent.volume                          | If set, qBittorrent will create a PVC for its config volume, else it will be put on general.storage.subPaths.config | {}                             |
+
+**Notes:**
+- By default, authentication for the Web UI is disabled. To enable it, set `qbittorrent.config.auth.enabled` to `true` and provide a username and PBKDF2 password hash.
+- The Web UI is available on the configured HTTP port (default: 8080).
+- Peer connections use port 6881 (TCP/UDP by default).
+- You can customize storage by providing a `volume` section, or use the shared config path.
+- Ingress and service options allow for flexible exposure of the Web UI and peer ports.
+
 ## Helpful use-cases
 
 ### Using a cluster-external NFS server

--- a/helm-charts/k8s-mediaserver/templates/qbittorrent-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/qbittorrent-resources.yml
@@ -1,0 +1,411 @@
+{{- if .Values.qbittorrent.enabled -}}
+---
+### SERVICE ACCOUNT & RBAC
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: qbittorrent-sa
+  labels:
+    {{- include "k8s-mediaserver.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: qbittorrent-role
+  labels:
+    {{- include "k8s-mediaserver.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: qbittorrent-rolebinding
+  labels:
+    {{- include "k8s-mediaserver.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: qbittorrent-role
+subjects:
+- kind: ServiceAccount
+  name: qbittorrent-sa
+---
+### CONFIGMAP
+## INIT-CONTAINER
+apiVersion: v1
+data:
+  init-qbittorrent.sh: |
+    #!/bin/bash
+    echo "### Initializing qBittorrent config ###"
+    mkdir -p /qbittorrent-config/qBittorrent
+    if [ ! -f /qbittorrent-config/qBittorrent/qBittorrent.conf ]; then
+      cp -n /init-qbittorrent/qBittorrent.conf /qbittorrent-config/qBittorrent/qBittorrent.conf
+      echo "### No configuration found, initialized with default settings ###"
+    else
+      echo "### Configuration found, using existing settings ###"
+    fi
+  qBittorrent.conf: |
+    [AutoRun]
+    enabled=false
+    program=
+    [BitTorrent]
+    Session\DefaultSavePath=/downloads/qbittorrent/complete
+    Session\DisableAutoTMMByDefault=false
+    Session\DisableAutoTMMTriggers\CategorySavePathChanged=false
+    Session\DisableAutoTMMTriggers\DefaultSavePathChanged=false
+    Session\Port={{ .Values.qbittorrent.service.peer.port }}
+    Session\QueueingSystemEnabled=true
+    Session\TempPath=/downloads/qbittorrent/incomplete
+    [Core]
+    AutoDeleteAddedTorrentFile=Never
+    [LegalNotice]
+    Accepted=true
+    [Meta]
+    MigrationVersion=4
+    [Network]
+    PortForwardingEnabled=true
+    Proxy\OnlyForTorrents=false
+    [Preferences]
+    Advanced\RecheckOnCompletion=false
+    Advanced\trackerPort=9000
+    Connection\PortRangeMin={{ .Values.qbittorrent.service.peer.port }}
+    Connection\ResolvePeerCountries=true
+    Connection\UPnP=false
+    Downloads\SavePath=/downloads/qbittorrent/complete
+    Downloads\TempPath=/downloads/qbittorrent/incomplete
+    WebUI\Address=0.0.0.0
+    WebUI\AlternativeUIEnabled=false
+    WebUI\AuthSubnetWhitelist=@Invalid()
+    WebUI\AuthSubnetWhitelistEnabled=false
+    WebUI\BanDuration=3600
+    WebUI\CSRFProtection=true
+    WebUI\ClickjackingProtection=true
+    WebUI\HTTPS\Enabled=false
+    WebUI\HostHeaderValidation=true
+    WebUI\LocalHostAuth={{ .Values.qbittorrent.config.auth.enabled }}
+    {{- if .Values.qbittorrent.config.auth.enabled }}
+    WebUI\Password_PBKDF2="@ByteArray({{ .Values.qbittorrent.config.auth.passwordHash }})"
+    WebUI\Username={{ .Values.qbittorrent.config.auth.username }}
+    {{- else }}
+    WebUI\Password_PBKDF2=
+    WebUI\Username=
+    {{- end }}
+    WebUI\Port={{ .Values.qbittorrent.container.port.http }}
+    WebUI\RootFolder=
+    WebUI\SecureCookie=true
+    WebUI\ServerDomains=*
+    WebUI\SessionTimeout=3600
+    WebUI\UseUPnP=false
+    WebUI\ReverseProxySupportEnabled=true
+    WebUI\HostHeaderValidation=false
+    WebUI\TrustedReverseProxiesList=*
+kind: ConfigMap
+metadata:
+  name: init-qbittorrent-cm
+---
+## APPLICATION
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: qbittorrent-config
+data:
+  PGID: "{{ .Values.general.pgid }}"
+  PUID: "{{ .Values.general.puid }}"
+  TZ: "{{ .Values.qbittorrent.config.timezone | default "UTC" }}"
+  WEBUI_PORT: "{{ .Values.qbittorrent.container.port.http }}"
+---
+### DEPLOYMENT
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: qbittorrent
+  labels:
+    {{- include "k8s-mediaserver.labels" . | nindent 4 }}
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "k8s-mediaserver.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "k8s-mediaserver.selectorLabels" . | nindent 8 }}
+        app: qbittorrent
+    spec:
+      {{- if .Values.qbittorrent.serviceAccountName }}
+      serviceAccountName: {{ .Values.qbittorrent.serviceAccountName }}
+      {{- else }}
+      serviceAccountName: qbittorrent-sa
+      {{- end }}
+      initContainers:
+        - name: config-qbittorrent
+          image: docker.io/ubuntu:jammy
+          command: ["/init-qbittorrent/init-qbittorrent.sh"]
+          volumeMounts:
+            - mountPath: /init-qbittorrent
+              name: init-files-qbittorrent
+          {{ if .Values.qbittorrent.volume }}
+            - name: {{ .Values.qbittorrent.volume.name }}
+              mountPath: /qbittorrent-config
+          {{ else }}
+            - name: mediaserver-volume
+              mountPath: "/qbittorrent-config"
+              subPath: "{{ .Values.general.storage.subPaths.config }}/qbittorrent"
+          {{ end }}
+          securityContext:
+            runAsUser: {{ .Values.general.puid }}
+            runAsGroup: {{ .Values.general.pgid }}
+      containers:
+        - name: {{ .Chart.Name }}
+          envFrom:
+            - configMapRef:
+                name: qbittorrent-config
+          image: "{{ .Values.qbittorrent.container.image }}:{{ .Values.qbittorrent.container.tag | default .Values.general.image_tag }}"
+          imagePullPolicy: Always
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: {{ .Values.qbittorrent.container.port.http }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 20
+          ports:
+            - name: qbit-web
+              containerPort: {{ .Values.qbittorrent.container.port.http }}
+              protocol: TCP
+            - name: qbit-peer-tcp
+              containerPort: {{ .Values.qbittorrent.container.port.peer }}
+              protocol: TCP
+            - name: qbit-peer-udp
+              containerPort: {{ .Values.qbittorrent.container.port.peer }}
+              protocol: UDP
+          volumeMounts:
+          {{ if .Values.qbittorrent.volume }}
+            - name: {{ .Values.qbittorrent.volume.name }}
+              mountPath: /config
+          {{ else }}
+            - name: mediaserver-volume
+              mountPath: "/config"
+              subPath: "{{ .Values.general.storage.subPaths.config }}/qbittorrent"
+          {{ end }}
+            - name: mediaserver-volume
+              mountPath: "/downloads"
+              subPath: "{{ .Values.general.storage.subPaths.downloads }}"
+          {{- with .Values.qbittorrent.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- if .Values.qbittorrent.extraContainers }}
+        {{- toYaml .Values.qbittorrent.extraContainers | nindent 8 }}
+      {{- end }}
+      volumes:
+        {{ if not .Values.general.storage.customVolume }}
+        - name: mediaserver-volume
+          persistentVolumeClaim:
+            claimName: {{ .Values.general.storage.pvcName }}
+        {{ else }}
+        - name: mediaserver-volume
+          {{- toYaml .Values.general.storage.volumes | nindent 10 }}
+        {{ end }}
+        {{ if .Values.qbittorrent.volume }}
+        - name: {{ .Values.qbittorrent.volume.name }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.qbittorrent.volume.name }}
+        {{ end }}
+        - name: init-files-qbittorrent
+          configMap:
+            defaultMode: 493
+            name: init-qbittorrent-cm
+      {{- if .Values.qbittorrent.extraVolumes }}
+        {{- toYaml .Values.qbittorrent.extraVolumes | nindent 8 }}
+      {{- end }}
+      {{- with merge .Values.qbittorrent.container.nodeSelector .Values.general.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if eq .Values.general.podDistribution "cluster" }}
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - {{ .Release.Name }}
+              topologyKey: "kubernetes.io/hostname"
+            weight: 100
+      {{- else if eq .Values.general.podDistribution "spread" }}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: "kubernetes.io/hostname"
+        whenUnsatisfiable: "ScheduleAnyway"
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- end }}
+---
+### SERVICES
+apiVersion: v1
+kind: Service
+metadata:
+  name: qbittorrent
+  labels:
+    {{- include "k8s-mediaserver.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.qbittorrent.service.http.type }}
+  ports:
+    - port: {{ .Values.qbittorrent.service.http.port }}
+      targetPort: {{ .Values.qbittorrent.container.port.http }}
+      protocol: TCP
+      name: qbit-web
+{{ if eq .Values.qbittorrent.service.http.type "NodePort" }}
+      nodePort: {{ .Values.qbittorrent.service.http.nodePort }}
+{{ end }}
+  selector:
+    app: qbittorrent
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qbittorrent-peer-tcp
+  labels:
+    {{- include "k8s-mediaserver.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.qbittorrent.service.peer.type }}
+  ports:
+    - port: {{ .Values.qbittorrent.service.peer.port }}
+      targetPort: {{ .Values.qbittorrent.container.port.peer }}
+      protocol: TCP
+      name: qbit-peer-tcp
+{{ if eq .Values.qbittorrent.service.peer.type "NodePort" }}
+      nodePort: {{ .Values.qbittorrent.service.peer.nodePort }}
+{{ end }}
+  selector:
+    app: qbittorrent
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qbittorrent-peer-udp
+  labels:
+    {{- include "k8s-mediaserver.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.qbittorrent.service.peer.type }}
+  ports:
+    - port: {{ .Values.qbittorrent.service.peer.port }}
+      targetPort: {{ .Values.qbittorrent.container.port.peer }}
+      protocol: UDP
+      name: qbit-peer-udp
+{{ if eq .Values.qbittorrent.service.peer.type "NodePort" }}
+      nodePort: {{ .Values.qbittorrent.service.peer.nodePortUDP }}
+{{ end }}
+  selector:
+    app: qbittorrent
+---
+{{ if .Values.qbittorrent.service.http.extraLBService }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: qbittorrent-lb
+  {{- with .Values.qbittorrent.service.http.extraLBAnnotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "k8s-mediaserver.labels" . | nindent 4 }}
+spec:
+  type: LoadBalancer
+  ports:
+    - port: {{ .Values.qbittorrent.service.http.port }}
+      targetPort: {{ .Values.qbittorrent.container.port.http }}
+      protocol: TCP
+      name: qbit-web
+  selector:
+    app: qbittorrent
+---
+{{ end }}
+{{ if .Values.qbittorrent.service.peer.extraLBService }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: qbittorrent-lb-peer-tcp
+  {{- with .Values.qbittorrent.service.peer.extraLBAnnotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "k8s-mediaserver.labels" . | nindent 4 }}
+spec:
+  type: LoadBalancer
+  ports:
+    - port: {{ .Values.qbittorrent.service.peer.port }}
+      targetPort: {{ .Values.qbittorrent.container.port.peer }}
+      protocol: TCP
+      name: qbit-peer-tcp
+  selector:
+    app: qbittorrent
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qbittorrent-lb-peer-udp
+  {{- with .Values.qbittorrent.service.peer.extraLBAnnotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "k8s-mediaserver.labels" . | nindent 4 }}
+spec:
+  type: LoadBalancer
+  ports:
+    - port: {{ .Values.qbittorrent.service.peer.port }}
+      targetPort: {{ .Values.qbittorrent.container.port.peer }}
+      protocol: UDP
+      name: qbit-peer-udp
+  selector:
+    app: qbittorrent
+{{ end }}
+---
+### INGRESS
+{{ if .Values.qbittorrent.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: qbittorrent
+  labels:
+    {{- include "k8s-mediaserver.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.qbittorrent.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+{{- if .Values.qbittorrent.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.general.qbittorrent_ingress_host | quote }}
+      secretName: {{ .Values.qbittorrent.ingress.tls.secretName }}
+{{ end }}
+  ingressClassName: {{ .Values.general.ingress.ingressClassName }}
+  rules:
+    - host: {{ .Values.general.qbittorrent_ingress_host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: qbittorrent
+                port:
+                  number: {{ .Values.qbittorrent.service.http.port }}
+{{ end }}
+{{ end }} 

--- a/helm-charts/k8s-mediaserver/templates/storage-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/storage-resources.yml
@@ -221,3 +221,30 @@ spec:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
+
+{{- with .Values.qbittorrent.volume }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .name }}
+  {{ with .annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{ with .labels }}
+  labels:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .accessModes }}
+  resources:
+    requests:
+      storage: {{ .storage }}
+  storageClassName: {{ .storageClassName }}
+  {{ with .selector }}
+  selector:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/k8s-mediaserver/values.yaml
+++ b/helm-charts/k8s-mediaserver/values.yaml
@@ -6,6 +6,7 @@ general:
   ingress_host: k8s-mediaserver.k8s.test
   plex_ingress_host: k8s-plex.k8s.test
   jellyfin_ingress_host: k8s-jelly.k8s.test
+  qbittorrent_ingress_host: k8s-qbit.k8s.test
   image_tag: latest
   podDistribution: cluster # can be "spread" or "cluster"
   #UID to run the process with
@@ -25,6 +26,7 @@ general:
       movies: media/movies
       downloads: downloads
       transmission: transmission
+      qbittorrent: qbittorrent
       sabnzbd: sabnzbd
       config: config
     volumes: {}
@@ -309,6 +311,55 @@ jellyfin:
   #    memory: 100Mi
   volume: {}
   #  name: pvc-jellyfin-config
+  #  storageClassName: longhorn
+  #  annotations: {}
+  #  labels: {}
+  #  accessModes: ReadWriteOnce
+  #  storage: 5Gi
+  #  selector: {}
+
+qbittorrent:
+  enabled: true  # Set to true to enable
+  container:
+    image: ghcr.io/linuxserver/qbittorrent
+    tag: version-5.0.3-r0
+    nodeSelector: {}
+    port:
+      http: 8080
+      peer: 6881
+  service:
+    http:
+      type: ClusterIP
+      port: 8080
+      # if type is NodePort, nodePort must be set
+      nodePort:
+      # Defines an additional LB service, requires cloud provider service or MetalLB
+      extraLBService: false
+      extraLBAnnotations: {}
+    peer:
+      type: ClusterIP
+      port: 6881
+      # if type is NodePort, nodePort and nodePortUDP must be set
+      nodePort:
+      nodePortUDP:
+      # Defines an additional LB service, requires cloud provider service or MetalLB
+      extraLBService: false
+      extraLBAnnotations: {}
+  ingress:
+    enabled: true
+    annotations: {}  # Additional ingress annotations if needed
+    tls:
+      enabled: false
+      secretName: ""
+  config:
+    timezone: "UTC"
+    auth:
+      enabled: false  # Authentication is disabled by default
+      username: "admin"  # Only used if config.auth.enabled is true
+      passwordHash: ""  # Only used if config.auth.enabled is true, PBKDF2 hash format
+  resources: {}
+  volume: {}
+  #  name: pvc-qbittorrent-config
   #  storageClassName: longhorn
   #  annotations: {}
   #  labels: {}


### PR DESCRIPTION
### Summary

This pull request introduces Helm chart support for qBittorrent and updates storage and values configuration to support this addition.

### Changes

- **Added:**  
  - `helm-charts/k8s-mediaserver/templates/qbittorrent-resources.yml`  
    New Helm template for deploying and managing qBittorrent as part of the mediaserver stack.

- **Modified:**  
  - `helm-charts/k8s-mediaserver/templates/storage-resources.yml`  
    Updated to support persistent storage requirements for qBittorrent and possibly other improvements or refactoring.
  - `helm-charts/k8s-mediaserver/values.yaml`  
    Added configuration values for qBittorrent and updated documentation/comments as needed.

### Motivation

- qbit provides far more features than transmission does 

