### PR TITLE
 Update Volume Mounts for Plex and Jackett

### DIFF
--- a/helm-charts/k8s-mediaserver/templates/jackett-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/jackett-resources.yml
@@ -83,7 +83,7 @@ spec:
           volumeMounts:
           {{- if .Values.jackett.volume }}
             - name: {{ .Values.jackett.volume.name }}
-              mountPath: /config
+              mountPath: /config/Jackett
           {{- else }}
             - name: mediaserver-volume
               mountPath: "/config"

--- a/helm-charts/k8s-mediaserver/templates/plex-resources.yml
+++ b/helm-charts/k8s-mediaserver/templates/plex-resources.yml
@@ -77,6 +77,9 @@ spec:
             - name: mediaserver-volume
               mountPath: /tv
               subPath: "{{ .Values.general.storage.subPaths.tv }}"
+            - name: mediaserver-volume
+              mountPath: /downloads
+              subPath: "{{ .Values.general.storage.subPaths.downloads }}"
           {{- with .Values.plex.resources }}
           resources:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
### Summary

This pull request updates the volume mount configurations for the Plex and Jackett Helm chart templates to improve storage management and configuration consistency.

### Changes

- **Plex (`plex-resources.yml`):**
  - Updated the `mediaserver-volume` mount for `/downloads` to use a dynamic subPath:
    ```yaml
    - name: mediaserver-volume
      mountPath: /downloads
      subPath: "{{ .Values.general.storage.subPaths.downloads }}"
    ```
    This allows the downloads directory to be customized via Helm values, improving flexibility for different deployment scenarios.

- **Jackett (`jackett-resources.yml`):**
  - Updated the mount path for Jackett configuration:
    ```yaml
    mountPath: /config/Jackett
    ```
    This ensures Jackett’s configuration is stored in the correct directory, aligning with best practices and possibly fixing issues with persistent configuration.

### Motivation

- To provide more flexible and configurable storage options for Plex downloads.
- To ensure Jackett’s configuration is mounted in the correct location for persistence and compatibility.

